### PR TITLE
re-exporting modules, and simple tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 cabal.sandbox.config
 dist
 .stack-work
+*~
+*.o
+*.hi

--- a/dejafu/DejaFu/Control/Concurrent.hs
+++ b/dejafu/DejaFu/Control/Concurrent.hs
@@ -1,0 +1,7 @@
+{-# language NoMonomorphismRestriction #-}
+
+module DejaFu.Control.Concurrent where
+
+import Control.Monad.Conc.Class
+
+forkIO = Control.Monad.Conc.Class.fork

--- a/dejafu/DejaFu/Control/Concurrent/MVar.hs
+++ b/dejafu/DejaFu/Control/Concurrent/MVar.hs
@@ -1,0 +1,11 @@
+{-# language NoMonomorphismRestriction #-}
+
+module DejaFu.Control.Concurrent.MVar where
+
+import Control.Concurrent.CVar 
+
+newEmptyMVar = newEmptyCVar
+newMVar = newCVar
+takeMVar = takeCVar
+putMVar = putCVar
+

--- a/dejafu/DejaFu/Control/Concurrent/STM.hs
+++ b/dejafu/DejaFu/Control/Concurrent/STM.hs
@@ -1,0 +1,11 @@
+{-# language NoMonomorphismRestriction #-}
+
+module DejaFu.Control.Concurrent.STM where
+
+import Control.Monad.STM.Class
+import Control.Monad.Conc.Class
+
+newTVar = Control.Monad.STM.Class.newCTVar
+readTVar = Control.Monad.STM.Class.readCTVar
+writeTVar = Control.Monad.STM.Class.writeCTVar
+atomically = Control.Monad.Conc.Class.atomically

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -86,6 +86,10 @@ library
                      , Control.Concurrent.STM.CTVar
                      , Control.Concurrent.STM.CTMVar
 
+                     , DejaFu.Control.Concurrent
+                     , DejaFu.Control.Concurrent.STM
+                     , DejaFu.Control.Concurrent.MVar
+
                      , Test.DejaFu
                      , Test.DejaFu.Deterministic
                      , Test.DejaFu.Deterministic.Schedule

--- a/dejafu/examples/Diner.hs
+++ b/dejafu/examples/Diner.hs
@@ -1,0 +1,33 @@
+{-# language NoMonomorphismRestriction #-}
+
+import Test.DejaFu (autocheck, autocheck', MemType )
+
+import DejaFu.Control.Concurrent (forkIO)
+import DejaFu.Control.Concurrent.MVar ( newEmptyMVar, newMVar, takeMVar, putMVar )
+
+-- import Control.Concurrent ( forkIO)
+-- import Control.Concurrent.MVar ( newEmptyMVar, newMVar, takeMVar, putMVar )
+
+import Control.Monad ( void, forM, forever )
+import Prelude hiding ( take, drop )
+import System.IO ( hSetBuffering , stdout, BufferMode(..))
+
+main = do
+  -- hSetBuffering stdout LineBuffering ; dining
+  autocheck dining
+
+-- | deadlocking non-solution for dining philosophers
+dining = do
+  let n = 2
+  fs <- forM [1..n] $ \ _ -> newMVar ()
+  let left p = fs !! (p-1) ; right p = fs !! (mod p n)
+  forM [1..n] $ \ p ->
+    (if p < n then void . forkIO else id ) $ forever $ do
+      -- putStrLn $ "philo " ++ show p ++ " thinking"
+      take $ left p ; take $ right p
+      -- putStrLn $ "philo " ++ show p ++ " eating"
+      drop $ left p ; drop $ right p
+  return ()
+
+take f = takeMVar f
+drop f = putMVar f ()

--- a/dejafu/examples/Simple.hs
+++ b/dejafu/examples/Simple.hs
@@ -1,0 +1,22 @@
+{-# language NoMonomorphismRestriction #-}
+
+import Test.DejaFu (autocheck, autocheck', MemType )
+
+import DejaFu.Control.Concurrent (forkIO)
+import DejaFu.Control.Concurrent.STM (newTVar, readTVar, writeTVar, atomically)
+
+import Control.Monad ( void, forM )
+
+main = do
+  autocheck stmAtomic
+
+-- | Transactions are atomic.
+-- dejafu type: stmAtomic :: MonadConc m => m Int
+stmAtomic = do
+  x <- atomically $ newTVar (0::Int)
+  forM [1..3] $ \ _ -> forkIO . atomically $ do
+      writeTVar x 1
+      writeTVar x 2
+  atomically $ readTVar x
+
+  


### PR DESCRIPTION
To make using dejafu easier: make it so that imports for the "real thing" like
```
import Control.Concurrent (forkIO)
import Control.Concurrent.STM (newTVar, readTVar, writeTVar, atomically)
```
can be changed systematically to
```
import DejaFu.Control.Concurrent (forkIO)
import DejaFu.Control.Concurrent.STM (newTVar, readTVar, writeTVar, atomically)
```
and the rest of the program remains unchanged.

This means some new modules that just re-export stuff under standard names.

Yes, the types probably don't match, but still ...
