### PR TITLE
Make cancel blocking

### DIFF
--- a/concurrency/Control/Concurrent/Classy/Async.hs
+++ b/concurrency/Control/Concurrent/Classy/Async.hs
@@ -292,7 +292,7 @@ waitCatchSTM (Async _ w) = w
 -- 'cancel' can of course be obtained by wrapping 'cancel' itself in
 -- 'async'.
 cancel :: MonadConc m => Async m a -> m ()
-cancel (Async tid _) = throwTo tid ThreadKilled
+cancel a@(Async tid _) = throwTo tid ThreadKilled <* waitCatch a
 
 -- | Cancel an asynchronous action by throwing the supplied exception
 -- to it.


### PR DESCRIPTION
In the documentation of `cancel`, it is said to be blocking, waiting on
the cancelled `async` to die. It seems to me that is not the case.

This patch simply applies the code written by Simon Marlow in order
to wait for the termination of the `async`.

See:
https://hackage.haskell.org/package/async-2.1.1/docs/src/Control.Concurrent.Async.html#cancel