### PR TITLE
Named versions of async*.

### DIFF
--- a/concurrency/Control/Concurrent/Classy/Async.hs
+++ b/concurrency/Control/Concurrent/Classy/Async.hs
@@ -32,9 +32,13 @@ module Control.Concurrent.Classy.Async
 
   -- * Spawning
   , async
+  , asyncN
   , asyncOn
+  , asyncOnN
   , asyncWithUnmask
+  , asyncWithUnmaskN
   , asyncOnWithUnmask
+  , asyncOnWithUnmaskN
 
   -- * Spawning with automatic 'cancel'ation
   , withAsync
@@ -178,11 +182,23 @@ instance (MonadConc m, Monoid a) => Monoid (Concurrently m a) where
 async :: MonadConc m => m a -> m (Async m a)
 async = asyncUsing fork
 
+-- | Like 'async', but taking a name for better debugging information.
+--
+-- @since unreleased
+asyncN :: MonadConc m => String -> m a -> m (Async m a)
+asyncN name = asyncUsing (forkN name)
+
 -- | Like 'async' but using 'forkOn' internally.
 --
 -- @since 1.1.1.0
 asyncOn :: MonadConc m => Int -> m a -> m (Async m a)
 asyncOn = asyncUsing . forkOn
+
+-- | Like 'asyncOn' but taking a name for better debugging information.
+--
+-- @since unreleased
+asyncOnN :: MonadConc m => String -> Int -> m a -> m (Async m a)
+asyncOnN name = asyncUsing . (forkOnN name)
 
 -- | Like 'async' but using 'forkWithUnmask' internally.
 --
@@ -190,11 +206,23 @@ asyncOn = asyncUsing . forkOn
 asyncWithUnmask :: MonadConc m => ((forall b. m b -> m b) -> m a) -> m (Async m a)
 asyncWithUnmask = asyncUnmaskUsing forkWithUnmask
 
+-- | Like 'asyncWithUnmask' but taking a name for better debugging information.
+--
+-- @since unreleased
+asyncWithUnmaskN :: MonadConc m => String -> ((forall b. m b -> m b) -> m a) -> m (Async m a)
+asyncWithUnmaskN name = asyncUnmaskUsing (forkWithUnmaskN name)
+
 -- | Like 'asyncOn' but using 'forkOnWithUnmask' internally.
 --
 -- @since 1.1.1.0
 asyncOnWithUnmask :: MonadConc m => Int -> ((forall b. m b -> m b) -> m a) -> m (Async m a)
 asyncOnWithUnmask i = asyncUnmaskUsing (forkOnWithUnmask i)
+
+-- | Like 'asyncOnWithUnmask' but taking a name for better debugging information.
+--
+-- @since unreleased
+asyncOnWithUnmaskN :: MonadConc m => String -> Int -> ((forall b. m b -> m b) -> m a) -> m (Async m a)
+asyncOnWithUnmaskN name i = asyncUnmaskUsing (forkOnWithUnmaskN name i)
 
 -- | Fork a thread with the given forking function
 asyncUsing :: MonadConc m => (m () -> m (ThreadId m)) -> m a -> m (Async m a)


### PR DESCRIPTION
This PR introduces named versions of `async`, `asyncOn`, etc. by reusing the named versions of `fork`.
We have many asyncs in our tests and being able to give them a name would be very helpful, as debugging traces are often illegible.

However, I expect that this might not be the right place/module for this change. I imagine you want to keep this interface as close as possible to that of the unclassy `Control.Concurrent.Async`. Hopefully, this may start a discussion on the best way to proceed.