### PR TITLE
check handlers are not empty when popping them

### DIFF
--- a/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
@@ -92,7 +92,9 @@ catching h = M.adjust $ \thread ->
 
 -- | Remove the most recent exception handler.
 uncatching :: ThreadId -> Threads n r -> Threads n r
-uncatching = M.adjust $ \thread -> thread { _handlers = tail $ _handlers thread }
+uncatching = M.adjust $ \thread -> thread { _handlers = if null (_handlers thread)
+                                                        then []
+                                                        else tail (_handlers thread) }
 
 -- | Raise an exception in a thread.
 except :: (MaskingState -> Action n r) -> [Handler n r] -> ThreadId -> Threads n r -> Threads n r


### PR DESCRIPTION
I noticed that in some cases my tests were failing with a cryptic error on `tail: empty list` which I finally nailed down to this code in dejafu. I am not sure this is the right thing to do, I guess ensuring there's always a handler avalable would be better but this is just to start a conversation...