### PR TITLE
Change argument order for test functions

### DIFF
--- a/dejafu-tests/Cases/Discard.hs
+++ b/dejafu-tests/Cases/Discard.hs
@@ -16,12 +16,9 @@ tests = toTestList
       \x -> if x == Right 3 then Just DiscardResultAndTrace else Nothing
   ]
   where
-    check name xs f = testDejafuDiscard f defaultWay defaultMemType nondet name (gives' xs)
-
-nondet :: MonadConc m => m Int
-nondet = do
-  mvar <- newEmptyMVar
-  _ <- fork $ putMVar mvar 1
-  _ <- fork $ putMVar mvar 2
-  _ <- fork $ putMVar mvar 3
-  readMVar mvar
+    check name xs f = testDejafuDiscard f defaultWay defaultMemType name (gives' xs) $ do
+      mvar <- newEmptyMVar
+      _ <- fork $ putMVar mvar 1
+      _ <- fork $ putMVar mvar 2
+      _ <- fork $ putMVar mvar 3
+      readMVar mvar

--- a/dejafu-tests/Cases/Litmus.hs
+++ b/dejafu-tests/Cases/Litmus.hs
@@ -48,9 +48,9 @@ tests =
 
 litmusTest :: (Eq a, Show a) => String -> ConcIO a -> [a] -> [a] -> [a] -> Test
 litmusTest name act sq tso pso = testGroup name . hUnitTestToTests $ test
-  [ testDejafuWay defaultWay SequentialConsistency act "SQ"  (gives' sq)
-  , testDejafuWay defaultWay TotalStoreOrder       act "TSO" (gives' tso)
-  , testDejafuWay defaultWay PartialStoreOrder     act "PSO" (gives' pso)
+  [ testDejafuWay defaultWay SequentialConsistency "SQ"  (gives' sq)  act
+  , testDejafuWay defaultWay TotalStoreOrder       "TSO" (gives' tso) act
+  , testDejafuWay defaultWay PartialStoreOrder     "PSO" (gives' pso) act
   ]
 
 -- | Run a litmus test against the three different memory models, and

--- a/dejafu-tests/Common.hs
+++ b/dejafu-tests/Common.hs
@@ -34,7 +34,7 @@ instance IsTest TH.Test where
 instance IsTest T where
   toTestList (T n c p) = toTestList (BT n c p defaultBounds)
   toTestList (BT n c p b) = toTestList . testGroup n $
-    let mk way name = testDejafuWay way defaultMemType c name p
+    let mk way name = testDejafuWay way defaultMemType name p c
         g = mkStdGen 0
     in [ mk (systematically b) "systematically"
        , mk (uniformly g 100) "uniformly"
@@ -53,7 +53,7 @@ testGroup :: IsTest t => String -> t -> TF.Test
 testGroup name = TF.testGroup name . toTestList
 
 djfu :: Show a => String -> Predicate a -> ConcIO a -> TF.Test
-djfu name p c = hunitTest $ testDejafu c name p
+djfu name p c = hunitTest $ testDejafu name p c
 
 djfuT :: Show a => String -> Predicate a -> ConcIO a -> [TF.Test]
 djfuT name p c = toTestList $ T name c p

--- a/dejafu-tests/Examples/Philosophers.hs
+++ b/dejafu-tests/Examples/Philosophers.hs
@@ -12,8 +12,8 @@ import Test.HUnit.DejaFu
 
 tests :: [Test]
 tests = hUnitTestToTests $ test
-  [ testDejafuWay way defaultMemType (philosophers 3) "deadlocks" deadlocksSometimes
-  , testDejafuWay way defaultMemType (philosophers 3) "loops"     abortsSometimes
+  [ testDejafuWay way defaultMemType "deadlocks" deadlocksSometimes (philosophers 3)
+  , testDejafuWay way defaultMemType "loops"     abortsSometimes    (philosophers 3)
   ]
 
 -- | Shorter execution length bound

--- a/dejafu-tests/Examples/SearchParty.hs
+++ b/dejafu-tests/Examples/SearchParty.hs
@@ -34,7 +34,7 @@ import Examples.SearchParty.Impredicative
 
 tests :: [Test]
 tests = hUnitTestToTests $ test
-  [ testDejafu concFilter "concurrent filter" (failing checkResultLists)
+  [ testDejafu "concurrent filter" (failing checkResultLists) concFilter
   ]
 
 -- | Filter a list concurrently.

--- a/dejafu/CHANGELOG.markdown
+++ b/dejafu/CHANGELOG.markdown
@@ -20,6 +20,8 @@ This project is versioned according to the [Package Versioning Policy](https://p
 
     It is no longer possible to test things in `ST`.
 
+- All testing functions now take the action to test as the last parameter.
+
 - The `autocheckIO`, `dejafuIO`, `dejafusIO`, `autocheckWayIO`, `dejafuWayIO`, `dejafusWayIO`,
   `dejafuDiscardIO`, `runTestM`, and `runTestWayM` functions are now gone.
 

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -310,23 +310,12 @@ import           Test.DejaFu.SCT
 -- @since 1.0.0.0
 autocheck :: (MonadConc n, MonadIO n, MonadRef r n, Eq a, Show a)
   => ConcT r n a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> n Bool
 autocheck = autocheckWay defaultWay defaultMemType
 
 -- | Variant of 'autocheck' which takes a way to run the program and a
 -- memory model.
---
--- Schedule bounding is used to filter the large number of possible
--- schedules, and can be iteratively increased for further coverage
--- guarantees. Empirical studies (/Concurrency Testing Using Schedule
--- Bounding: an Empirical Study/, P. Thompson, A. Donaldson, and
--- A. Betts) have found that many concurrency bugs can be exhibited
--- with as few as two threads and two pre-emptions, which is part of
--- what 'dejafus' uses.
---
--- __Warning:__ Using larger bounds will almost certainly
--- significantly increase the time taken to test!
 --
 -- @since 1.0.0.0
 autocheckWay :: (MonadConc n, MonadIO n, MonadRef r n, Eq a, Show a)
@@ -335,7 +324,7 @@ autocheckWay :: (MonadConc n, MonadIO n, MonadRef r n, Eq a, Show a)
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> ConcT r n a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> n Bool
 autocheckWay way memtype = dejafusWay way memtype autocheckCases
 
@@ -353,11 +342,11 @@ autocheckCases =
 -- @since 1.0.0.0
 dejafu :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
   => String
-  -- ^ The name of the test
+  -- ^ The name of the test.
   -> ProPredicate a b
-  -- ^ The predicate to check
+  -- ^ The predicate to check.
   -> ConcT r n a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> n Bool
 dejafu = dejafuWay defaultWay defaultMemType
 
@@ -371,11 +360,11 @@ dejafuWay :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> String
-  -- ^ The name of the test
+  -- ^ The name of the test.
   -> ProPredicate a b
-  -- ^ The predicate to check
+  -- ^ The predicate to check.
   -> ConcT r n a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> n Bool
 dejafuWay = dejafuDiscard (const Nothing)
 
@@ -390,11 +379,11 @@ dejafuDiscard :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> String
-  -- ^ The name of the test
+  -- ^ The name of the test.
   -> ProPredicate a b
-  -- ^ The predicate to check
+  -- ^ The predicate to check.
   -> ConcT r n a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> n Bool
 dejafuDiscard discard way memtype name test conc = do
   let discarder = strengthenDiscard discard (pdiscard test)
@@ -407,9 +396,9 @@ dejafuDiscard discard way memtype name test conc = do
 -- @since 1.0.0.0
 dejafus :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
   => [(String, ProPredicate a b)]
-  -- ^ The list of predicates (with names) to check
+  -- ^ The list of predicates (with names) to check.
   -> ConcT r n a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> n Bool
 dejafus = dejafusWay defaultWay defaultMemType
 
@@ -423,9 +412,9 @@ dejafusWay :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> [(String, ProPredicate a b)]
-  -- ^ The list of predicates (with names) to check
+  -- ^ The list of predicates (with names) to check.
   -> ConcT r n a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> n Bool
 dejafusWay way memtype tests conc = do
     traces  <- runSCTDiscard discarder way memtype conc

--- a/hunit-dejafu/CHANGELOG.markdown
+++ b/hunit-dejafu/CHANGELOG.markdown
@@ -19,6 +19,7 @@ This project is versioned according to the [Package Versioning Policy](https://p
 - The `ConcST` functions have been removed and replaced by the `ConcIO` functions.
 - The `Testable` and `Assertable` instances for `ConcST t ()` are gone.
 - All test functions are generalised to take a `ProPredicate`.
+- All test functions now take the action to test as the last parameter.
 
 ### Miscellaneous
 

--- a/hunit-dejafu/Test/HUnit/DejaFu.hs
+++ b/hunit-dejafu/Test/HUnit/DejaFu.hs
@@ -121,8 +121,7 @@ testAutoWay :: (Eq a, Show a)
   -> Conc.ConcIO a
   -- ^ The computation to test
   -> Test
-testAutoWay way memtype conc =
-  testDejafusWay way memtype conc autocheckCases
+testAutoWay way memtype = testDejafusWay way memtype autocheckCases
 
 -- | Predicates for the various autocheck functions.
 autocheckCases :: Eq a => [(String, Predicate a)]
@@ -136,12 +135,12 @@ autocheckCases =
 --
 -- @since 0.8.0.0
 testDejafu :: Show b
-  => Conc.ConcIO a
-  -- ^ The computation to test
-  -> String
-  -- ^ The name of the test.
+  => String
+  -- ^ The name of the test
   -> ProPredicate a b
   -- ^ The predicate to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> Test
 testDejafu = testDejafuWay defaultWay defaultMemType
 
@@ -154,12 +153,12 @@ testDejafuWay :: Show b
   -- ^ How to execute the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> Conc.ConcIO a
-  -- ^ The computation to test
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
   -- ^ The predicate to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> Test
 testDejafuWay = testDejafuDiscard (const Nothing)
 
@@ -173,15 +172,15 @@ testDejafuDiscard :: Show b
   -- ^ How to execute the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> Conc.ConcIO a
-  -- ^ The computation to test
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
   -- ^ The predicate to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> Test
-testDejafuDiscard discard way memtype conc name test =
-  testconc discard way memtype conc [(name, test)]
+testDejafuDiscard discard way memtype name test =
+  testconc discard way memtype [(name, test)]
 
 -- | Variant of 'testDejafu' which takes a collection of predicates to
 -- test. This will share work between the predicates, rather than
@@ -189,10 +188,10 @@ testDejafuDiscard discard way memtype conc name test =
 --
 -- @since 0.8.0.0
 testDejafus :: Show b
-  => Conc.ConcIO a
-  -- ^ The computation to test
-  -> [(String, ProPredicate a b)]
+  => [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> Test
 testDejafus = testDejafusWay defaultWay defaultMemType
 
@@ -205,10 +204,10 @@ testDejafusWay :: Show b
   -- ^ How to execute the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> Conc.ConcIO a
-  -- ^ The computation to test
   -> [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> Test
 testDejafusWay = testconc (const Nothing)
 
@@ -237,10 +236,10 @@ testconc :: Show b
   => (Either Failure a -> Maybe Discard)
   -> Way
   -> MemType
-  -> Conc.ConcIO a
   -> [(String, ProPredicate a b)]
+  -> Conc.ConcIO a
   -> Test
-testconc discard way memtype concio tests = case map toTest tests of
+testconc discard way memtype tests concio = case map toTest tests of
   [t] -> t
   ts  -> TestList ts
 

--- a/hunit-dejafu/Test/HUnit/DejaFu.hs
+++ b/hunit-dejafu/Test/HUnit/DejaFu.hs
@@ -105,7 +105,7 @@ assertableP = alwaysTrue $ \case
 -- @since 0.8.0.0
 testAuto :: (Eq a, Show a)
   => Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> Test
 testAuto = testAutoWay defaultWay defaultMemType
 
@@ -119,7 +119,7 @@ testAutoWay :: (Eq a, Show a)
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> Test
 testAutoWay way memtype = testDejafusWay way memtype autocheckCases
 
@@ -136,11 +136,11 @@ autocheckCases =
 -- @since 0.8.0.0
 testDejafu :: Show b
   => String
-  -- ^ The name of the test
+  -- ^ The name of the test.
   -> ProPredicate a b
-  -- ^ The predicate to check
+  -- ^ The predicate to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> Test
 testDejafu = testDejafuWay defaultWay defaultMemType
 
@@ -156,9 +156,9 @@ testDejafuWay :: Show b
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
-  -- ^ The predicate to check
+  -- ^ The predicate to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> Test
 testDejafuWay = testDejafuDiscard (const Nothing)
 
@@ -175,9 +175,9 @@ testDejafuDiscard :: Show b
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
-  -- ^ The predicate to check
+  -- ^ The predicate to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> Test
 testDejafuDiscard discard way memtype name test =
   testconc discard way memtype [(name, test)]
@@ -189,9 +189,9 @@ testDejafuDiscard discard way memtype name test =
 -- @since 0.8.0.0
 testDejafus :: Show b
   => [(String, ProPredicate a b)]
-  -- ^ The list of predicates (with names) to check
+  -- ^ The list of predicates (with names) to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> Test
 testDejafus = testDejafusWay defaultWay defaultMemType
 
@@ -205,9 +205,9 @@ testDejafusWay :: Show b
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> [(String, ProPredicate a b)]
-  -- ^ The list of predicates (with names) to check
+  -- ^ The list of predicates (with names) to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> Test
 testDejafusWay = testconc (const Nothing)
 

--- a/tasty-dejafu/CHANGELOG.markdown
+++ b/tasty-dejafu/CHANGELOG.markdown
@@ -19,6 +19,7 @@ This project is versioned according to the [Package Versioning Policy](https://p
 - The `ConcST` functions have been removed and replaced by the `ConcIO` functions.
 - The `IsTest` instance for `ConcST t (Maybe String)` is gone.
 - All test functions are generalised to take a `ProPredicate`.
+- All test functions now take the action to test as the last parameter.
 
 ### Miscellaneous
 

--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -138,7 +138,7 @@ instance IsOption Way where
 -- @since 0.8.0.0
 testAuto :: (Eq a, Show a)
   => Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> TestTree
 testAuto = testAutoWay defaultWay defaultMemType
 
@@ -152,7 +152,7 @@ testAutoWay :: (Eq a, Show a)
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> TestTree
 testAutoWay way memtype = testDejafusWay way memtype autocheckCases
 
@@ -171,9 +171,9 @@ testDejafu :: Show b
   => TestName
   -- ^ The name of the test.
   -> ProPredicate a b
-  -- ^ The predicate to check
+  -- ^ The predicate to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> TestTree
 testDejafu = testDejafuWay defaultWay defaultMemType
 
@@ -189,9 +189,9 @@ testDejafuWay :: Show b
   -> TestName
   -- ^ The name of the test.
   -> ProPredicate a b
-  -- ^ The predicate to check
+  -- ^ The predicate to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> TestTree
 testDejafuWay = testDejafuDiscard (const Nothing)
 
@@ -208,9 +208,9 @@ testDejafuDiscard :: Show b
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
-  -- ^ The predicate to check
+  -- ^ The predicate to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> TestTree
 testDejafuDiscard discard way memtype name test =
   testconc discard way memtype [(name, test)]
@@ -222,9 +222,9 @@ testDejafuDiscard discard way memtype name test =
 -- @since 0.8.0.0
 testDejafus :: Show b
   => [(TestName, ProPredicate a b)]
-  -- ^ The list of predicates (with names) to check
+  -- ^ The list of predicates (with names) to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> TestTree
 testDejafus = testDejafusWay defaultWay defaultMemType
 
@@ -238,9 +238,9 @@ testDejafusWay :: Show b
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> [(TestName, ProPredicate a b)]
-  -- ^ The list of predicates (with names) to check
+  -- ^ The list of predicates (with names) to check.
   -> Conc.ConcIO a
-  -- ^ The computation to test
+  -- ^ The computation to test.
   -> TestTree
 testDejafusWay = testconc (const Nothing)
 

--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -154,7 +154,7 @@ testAutoWay :: (Eq a, Show a)
   -> Conc.ConcIO a
   -- ^ The computation to test
   -> TestTree
-testAutoWay way memtype conc = testDejafusWay way memtype conc autocheckCases
+testAutoWay way memtype = testDejafusWay way memtype autocheckCases
 
 -- | Predicates for the various autocheck functions.
 autocheckCases :: Eq a => [(TestName, Predicate a)]
@@ -168,12 +168,12 @@ autocheckCases =
 --
 -- @since 0.8.0.0
 testDejafu :: Show b
-  => Conc.ConcIO a
-  -- ^ The computation to test
-  -> TestName
+  => TestName
   -- ^ The name of the test.
   -> ProPredicate a b
   -- ^ The predicate to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> TestTree
 testDejafu = testDejafuWay defaultWay defaultMemType
 
@@ -186,12 +186,12 @@ testDejafuWay :: Show b
   -- ^ How to execute the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> Conc.ConcIO a
-  -- ^ The computation to test
   -> TestName
   -- ^ The name of the test.
   -> ProPredicate a b
   -- ^ The predicate to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> TestTree
 testDejafuWay = testDejafuDiscard (const Nothing)
 
@@ -205,15 +205,15 @@ testDejafuDiscard :: Show b
   -- ^ How to execute the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> Conc.ConcIO a
-  -- ^ The computation to test
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
   -- ^ The predicate to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> TestTree
-testDejafuDiscard discard way memtype conc name test =
-  testconc discard way memtype conc [(name, test)]
+testDejafuDiscard discard way memtype name test =
+  testconc discard way memtype [(name, test)]
 
 -- | Variant of 'testDejafu' which takes a collection of predicates to
 -- test. This will share work between the predicates, rather than
@@ -221,10 +221,10 @@ testDejafuDiscard discard way memtype conc name test =
 --
 -- @since 0.8.0.0
 testDejafus :: Show b
-  => Conc.ConcIO a
-  -- ^ The computation to test
-  -> [(TestName, ProPredicate a b)]
+  => [(TestName, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> TestTree
 testDejafus = testDejafusWay defaultWay defaultMemType
 
@@ -237,10 +237,10 @@ testDejafusWay :: Show b
   -- ^ How to execute the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> Conc.ConcIO a
-  -- ^ The computation to test
   -> [(TestName, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check
+  -> Conc.ConcIO a
+  -- ^ The computation to test
   -> TestTree
 testDejafusWay = testconc (const Nothing)
 
@@ -300,10 +300,10 @@ testconc :: Show b
   => (Either Failure a -> Maybe Discard)
   -> Way
   -> MemType
-  -> Conc.ConcIO a
   -> [(TestName, ProPredicate a b)]
+  -> Conc.ConcIO a
   -> TestTree
-testconc discard way memtype concio tests = case map toTest tests of
+testconc discard way memtype tests concio = case map toTest tests of
   [t] -> t
   ts  -> testGroup "Deja Fu Tests" ts
 


### PR DESCRIPTION
This PR changes the order of arguments for test functions to have the concurrency action last.  This makes things consistent with other testing libraries, and just feels more convenient to write.  Implements #123.

## Implementation

- [x] Swap argument order

## Quality control

- [x] Proofreads docs for Test.DejaFu. HUnit.DejaFu, and Tasty.DejaFu
- [x] Changelog entries