### PR TITLE
Doctest all Haddock code examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
   - env: MODE=test RESOLVER=nightly
     addons: {apt: {packages: [libgmp-dev]}}
+  - env: MODE=doctest RESOLVER=lts-10
+    addons: {apt: {packages: [libgmp-dev]}}
   - env: MODE=style RESOLVER=lts-10
     addons: {apt: {packages: [libgmp-dev]}}
   allow_failures:
@@ -36,6 +38,7 @@ before_install:
 - if [[ -e .travis/$RESOLVER.yaml ]]; then mv .travis/$RESOLVER.yaml stack.yaml; else stack init --resolver=$RESOLVER; fi
 - stack --no-terminal setup
 - if [[ "$MODE" == "style" ]]; then stack --no-terminal install stylish-haskell; fi
+- if [[ "$MODE" == "doctest" ]]; then stack --no-terminal install doctest; fi
 
 # Run tests
 script:
@@ -57,6 +60,9 @@ script:
       ;;
     test)
       stack exec -- dejafu-tests --plain
+      ;;
+    doctest)
+      stack exec -- bash -c "DEJAFU_DOCTEST=y doctest dejafu/Test"
       ;;
   esac
   set +ex

--- a/README.markdown
+++ b/README.markdown
@@ -115,9 +115,9 @@ we'll get onto that shortly.  First, the result of testing:
 [pass] Never Deadlocks
 [pass] No Exceptions
 [fail] Consistent Result
-        "hello" S0----S1--S0--
+    "hello" S0----S1--S0--
 
-        "world" S0----S2--S0--
+    "world" S0----S2--S0--
 False
 ```
 

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -31,9 +31,9 @@ We can test it with dejafu like so:
 [pass] Never Deadlocks
 [pass] No Exceptions
 [fail] Consistent Result
-        "hello" S0----S1--S0--
+    "hello" S0----S1--S0--
 <BLANKLINE>
-        "world" S0----S2--S0--
+    "world" S0----S2--S0--
 False
 
 The 'autocheck' function takes a concurrent program to test and looks
@@ -198,13 +198,13 @@ We see something surprising if we ask for the results:
 [pass] Never Deadlocks
 [pass] No Exceptions
 [fail] Consistent Result
-        (False,True) S0---------S1----S0--S2----S0--
+    (False,True) S0---------S1----S0--S2----S0--
 <BLANKLINE>
-        (False,False) S0---------S1--P2----S1--S0---
+    (False,False) S0---------S1--P2----S1--S0---
 <BLANKLINE>
-        (True,False) S0---------S2----S1----S0---
+    (True,False) S0---------S2----S1----S0---
 <BLANKLINE>
-        (True,True) S0---------S1-C-S2----S1---S0---
+    (True,True) S0---------S1-C-S2----S1---S0---
 False
 
 It's possible for both threads to read the value @False@, even though
@@ -444,9 +444,9 @@ let relaxed = do
 -- [pass] Never Deadlocks
 -- [pass] No Exceptions
 -- [fail] Consistent Result
---         "hello" S0----S1--S0--
+--     "hello" S0----S1--S0--
 -- <BLANKLINE>
---         "world" S0----S2--S0--
+--     "world" S0----S2--S0--
 -- False
 --
 -- @since 1.0.0.0
@@ -463,24 +463,24 @@ autocheck = autocheckWay defaultWay defaultMemType
 -- [pass] Never Deadlocks
 -- [pass] No Exceptions
 -- [fail] Consistent Result
---         (False,True) S0---------S1----S0--S2----S0--
+--     (False,True) S0---------S1----S0--S2----S0--
 -- <BLANKLINE>
---         (False,False) S0---------S1--P2----S1--S0---
+--     (False,False) S0---------S1--P2----S1--S0---
 -- <BLANKLINE>
---         (True,False) S0---------S2----S1----S0---
+--     (True,False) S0---------S2----S1----S0---
 -- <BLANKLINE>
---         (True,True) S0---------S1-C-S2----S1---S0---
+--     (True,True) S0---------S1-C-S2----S1---S0---
 -- False
 --
 -- >>> autocheckWay defaultWay SequentialConsistency relaxed
 -- [pass] Never Deadlocks
 -- [pass] No Exceptions
 -- [fail] Consistent Result
---         (False,True) S0---------S1----S0--S2----S0--
+--     (False,True) S0---------S1----S0--S2----S0--
 -- <BLANKLINE>
---         (True,True) S0---------S1-P2----S1---S0---
+--     (True,True) S0---------S1-P2----S1---S0---
 -- <BLANKLINE>
---         (True,False) S0---------S2----S1----S0---
+--     (True,False) S0---------S2----S1----S0---
 -- False
 --
 -- @since 1.0.0.0
@@ -511,9 +511,9 @@ autocheckCases =
 --
 -- >>> dejafu "Test Name" alwaysSame example
 -- [fail] Test Name
---         "hello" S0----S1--S0--
+--     "hello" S0----S1--S0--
 -- <BLANKLINE>
---         "world" S0----S2--S0--
+--     "world" S0----S2--S0--
 -- False
 --
 -- @since 1.0.0.0
@@ -534,16 +534,16 @@ dejafu = dejafuWay defaultWay defaultMemType
 --
 -- >>> dejafuWay (randomly (mkStdGen 0) 100) defaultMemType "Randomly!" alwaysSame example
 -- [fail] Randomly!
---         "hello" S0----S1--S0--
+--     "hello" S0----S1--S0--
 -- <BLANKLINE>
---         "world" S0----S2--S0--
+--     "world" S0----S2--S0--
 -- False
 --
 -- >>> dejafuWay (randomly (mkStdGen 1) 100) defaultMemType "Randomly!" alwaysSame example
 -- [fail] Randomly!
---         "hello" S0----S1--S0--
+--     "hello" S0----S1--S0--
 -- <BLANKLINE>
---         "world" S0----S2--S1-S0--
+--     "world" S0----S2--S1-S0--
 -- False
 --
 -- @since 1.0.0.0
@@ -565,9 +565,9 @@ dejafuWay = dejafuDiscard (const Nothing)
 --
 -- >>> dejafuDiscard (\_ -> Just DiscardTrace) defaultWay defaultMemType "Discarding" alwaysSame example
 -- [fail] Discarding
---         "hello" <trace discarded>
+--     "hello" <trace discarded>
 -- <BLANKLINE>
---         "world" <trace discarded>
+--     "world" <trace discarded>
 -- False
 --
 -- @since 1.0.0.0
@@ -595,9 +595,9 @@ dejafuDiscard discard way memtype name test conc = do
 --
 -- >>> dejafus [("A", alwaysSame), ("B", deadlocksNever)] example
 -- [fail] A
---         "hello" S0----S1--S0--
+--     "hello" S0----S1--S0--
 -- <BLANKLINE>
---         "world" S0----S2--S0--
+--     "world" S0----S2--S0--
 -- [pass] B
 -- False
 --
@@ -615,11 +615,11 @@ dejafus = dejafusWay defaultWay defaultMemType
 --
 -- >>> dejafusWay defaultWay SequentialConsistency [("A", alwaysSame), ("B", exceptionsNever)] relaxed
 -- [fail] A
---         (False,True) S0---------S1----S0--S2----S0--
+--     (False,True) S0---------S1----S0--S2----S0--
 -- <BLANKLINE>
---         (True,True) S0---------S1-P2----S1---S0---
+--     (True,True) S0---------S1-P2----S1---S0---
 -- <BLANKLINE>
---         (True,False) S0---------S2----S1----S0---
+--     (True,False) S0---------S2----S1----S0---
 -- [pass] B
 -- False
 --
@@ -966,10 +966,10 @@ doTest name result = do
         putStrLn $ _failureMsg result
 
       let failures = _failures result
-      let output = map (\(r, t) -> putStrLn . indent doctest $ either showFail show r ++ " " ++ showTrace t) $ take 5 failures
+      let output = map (\(r, t) -> putStrLn . indent $ either showFail show r ++ " " ++ showTrace t) $ take 5 failures
       sequence_ $ intersperse (putStrLn "") output
       when (moreThan 5 failures) $
-        putStrLn (indent doctest "...")
+        putStrLn (indent "...")
 
     pure (_pass result)
   where
@@ -987,7 +987,5 @@ moreThan 0 _ = True
 moreThan n (_:rest) = moreThan (n-1) rest
 
 -- | Indent every line of a string.
-indent :: Bool -> String -> String
-indent doctest = intercalate "\n" . map (s++) . lines where
-  s | doctest = "        "
-    | otherwise = "\t"
+indent :: String -> String
+indent = intercalate "\n" . map ("    "++) . lines

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -56,24 +56,24 @@ We can see this by testing with different memory models:
   [pass] Never Deadlocks
   [pass] No Exceptions
   [fail] Consistent Result
-          (False,True) S0---------S1----S0--S2----S0--
+      (False,True) S0---------S1----S0--S2----S0--
 
-          (True,True) S0---------S1-P2----S1---S0---
+      (True,True) S0---------S1-P2----S1---S0---
 
-          (True,False) S0---------S2----S1----S0---
+      (True,False) S0---------S2----S1----S0---
   False
 
   > autocheckWay defaultWay TotalStoreOrder example
   [pass] Never Deadlocks
   [pass] No Exceptions
   [fail] Consistent Result
-          (False,True) S0---------S1----S0--S2----S0--
+      (False,True) S0---------S1----S0--S2----S0--
 
-          (False,False) S0---------S1--P2----S1--S0---
+      (False,False) S0---------S1--P2----S1--S0---
 
-          (True,False) S0---------S2----S1----S0---
+      (True,False) S0---------S2----S1----S0---
 
-          (True,True) S0---------S1-C-S2----S1---S0---
+      (True,True) S0---------S1-C-S2----S1---S0---
   False
 
 Traces for non-sequentially-consistent memory models show where

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -88,9 +88,9 @@ we'll get onto that shortly.  First, the result of testing:
   [pass] Never Deadlocks
   [pass] No Exceptions
   [fail] Consistent Result
-          "hello" S0----S1--S0--
+      "hello" S0----S1--S0--
 
-          "world" S0----S2--S0--
+      "world" S0----S2--S0--
   False
 
 There are no deadlocks or uncaught exceptions, which is good; but the


### PR DESCRIPTION
## Summary

Turn all code examples in the Haddocks into doctests which are checked in CI.  This should ensure that all examples remain up to date, and also force them to be self-contained.  Both of those properties are good!

There are two visible changes to make this work:

- When the `DEJAFU_DOCTEST` environment variable is set, the helpers in Test.DejaFu don't colour their output.
- All indented output uses four spaces.

**To do:**

- [x] Configure Travis to run doctests
- [x] Convert all Haddock examples to doctests (and fix any broken ones)
- [x] Render the Haddocks and check code examples still look nice

**Related issues:** #86


## Checklist

- [x] Travis builds the PR successfully