### PR TITLE
Validate DPOR data invariants

### DIFF
--- a/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
@@ -175,7 +175,7 @@ incorporateTrace conservative trace dpor0 = grow initialDepState (initialDPORThr
         sleep' = M.filterWithKey (\t a' -> not $ dependent state' tid a t a') sleep
     in DPOR
         { dporRunnable = S.fromList $ case rest of
-            ((_, runnable, _):_) -> map fst runnable
+            ((d', runnable, _):_) -> tidOf tid d' : map fst runnable
             [] -> []
         , dporTodo = M.empty
         , dporNext = case rest of


### PR DESCRIPTION
## Summary

Validates the DPOR data invariants & fixes an invariant violation in `incorporateTrace.grow`, where the taken decision was not included in the runnable set.

**Related issues:** #173 

## Checklist

- [x] Travis builds the PR successfully