### PR TITLE
Revert "Do not allow nightly builds to fail"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
   - env: MODE=style
     addons: {apt: {packages: [libgmp-dev]}}
+  allow_failures:
+  - env: MODE=test RESOLVER=nightly
 
 # Download and unpack the stack executable
 before_install:


### PR DESCRIPTION
## Summary

Allow Stackage Nightly builds to fail on Travis again. Having a build failure because a dependency hasn't been updated and has been temporarily removed is a pain.

This reverts commit 4b1d8c0f42811403ae164b9e1570a0e6c72a1ebc.
