### PR TITLE
Add `testDejafusDiscard`

### DIFF
--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -35,6 +35,7 @@ module Test.Tasty.DejaFu
   , testDejafusWay
 
   , testDejafuDiscard
+  , testDejafusDiscard
 
   -- ** Re-exports
   , Predicate
@@ -245,6 +246,23 @@ testDejafusWay :: Show b
   -- ^ The computation to test.
   -> TestTree
 testDejafusWay = testconc (const Nothing)
+
+-- | Variant of 'testDejafusWay' which can selectively discard results.
+--
+-- @since unreleased
+testDejafusDiscard :: Show b
+  => (Either Failure a -> Maybe Discard)
+  -- ^ Selectively discard results.
+  -> Way
+  -- ^ How to execute the concurrent program.
+  -> MemType
+  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -> [(TestName, ProPredicate a b)]
+  -- ^ The list of predicates (with names) to check.
+  -> Conc.ConcIO a
+  -- ^ The computation to test.
+  -> TestTree
+testDejafusDiscard = testconc
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds a variant of `testDejafuDiscard` to `tasty-dejafu`, that accepts a list of test-cases.
Such variants also exist for `testDejafus` and `testDejafusWay`.

## Checklist

**If this is fixing a bug or adding a feature:**

- [ ] Add new tests to dejafu-tests
    This adds a function to `tasty-dejafu` which doesn't seem to have a test-suite at the moment.