### PR TITLE
hunit-dejafu-1.0.1.0 and tasty-dejafu-1.0.1.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,7 +47,7 @@ There are a few different packages under the Déjà Fu umbrella:
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.4.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 1.0.0.1 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 1.0.0.0 | Deja Fu support for the HUnit test framework. |
+| [hunit-dejafu][h:hunit]  | 1.0.1.0 | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 1.0.0.1 | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.

--- a/README.markdown
+++ b/README.markdown
@@ -48,7 +48,7 @@ There are a few different packages under the Déjà Fu umbrella:
 | [concurrency][h:conc]    | 1.4.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 1.0.0.1 | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 1.0.1.0 | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 1.0.0.1 | Deja Fu support for the Tasty test framework. |
+| [tasty-dejafu][h:tasty]  | 1.0.1.0 | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -30,7 +30,7 @@ There are a few different packages under the Déjà Fu umbrella:
    ":hackage:`concurrency`",  "1.4.0.0", "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "1.0.0.1", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "1.0.1.0", "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "1.0.0.1", "Déjà Fu support for the tasty test framework"
+   ":hackage:`tasty-dejafu`", "1.0.1.0", "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -29,7 +29,7 @@ There are a few different packages under the Déjà Fu umbrella:
 
    ":hackage:`concurrency`",  "1.4.0.0", "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "1.0.0.1", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "1.0.0.0", "Déjà Fu support for the HUnit test framework"
+   ":hackage:`hunit-dejafu`", "1.0.1.0", "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "1.0.0.1", "Déjà Fu support for the tasty test framework"
 
 

--- a/hunit-dejafu/CHANGELOG.markdown
+++ b/hunit-dejafu/CHANGELOG.markdown
@@ -7,6 +7,17 @@ This project is versioned according to the [Package Versioning Policy](https://p
 *de facto* standard Haskell versioning scheme.
 
 
+unreleased
+----------
+
+### Test.HUnit.DejaFu
+
+- New `testDejafusDiscard` function (#200).
+
+
+---------------------------------------------------------------------------------------------------
+
+
 1.0.0.0
 -------
 

--- a/hunit-dejafu/CHANGELOG.markdown
+++ b/hunit-dejafu/CHANGELOG.markdown
@@ -7,12 +7,18 @@ This project is versioned according to the [Package Versioning Policy](https://p
 *de facto* standard Haskell versioning scheme.
 
 
-unreleased
-----------
+1.0.1.0
+-------
+
+- **Date**    2018-02-13
+- **Git tag** [hunit-dejafu-1.0.1.0][]
+- **Hackage** https://hackage.haskell.org/package/hunit-dejafu-1.0.1.0
 
 ### Test.HUnit.DejaFu
 
 - New `testDejafusDiscard` function (#200).
+
+[hunit-dejafu-1.0.1.0]: https://github.com/barrucadu/dejafu/releases/tag/hunit-dejafu-1.0.1.0
 
 
 ---------------------------------------------------------------------------------------------------

--- a/hunit-dejafu/Test/HUnit/DejaFu.hs
+++ b/hunit-dejafu/Test/HUnit/DejaFu.hs
@@ -216,7 +216,7 @@ testDejafusWay = testconc (const Nothing)
 -- | Variant of 'testDejafusWay' which can selectively discard
 -- results, beyond what each predicate already discards.
 --
--- @since unreleased
+-- @since 1.0.1.0
 testDejafusDiscard :: Show b
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.

--- a/hunit-dejafu/Test/HUnit/DejaFu.hs
+++ b/hunit-dejafu/Test/HUnit/DejaFu.hs
@@ -213,6 +213,24 @@ testDejafusWay :: Show b
   -> Test
 testDejafusWay = testconc (const Nothing)
 
+-- | Variant of 'testDejafusWay' which can selectively discard
+-- results, beyond what each predicate already discards.
+--
+-- @since unreleased
+testDejafusDiscard :: Show b
+  => (Either Failure a -> Maybe Discard)
+  -- ^ Selectively discard results.
+  -> Way
+  -- ^ How to execute the concurrent program.
+  -> MemType
+  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -> [(String, ProPredicate a b)]
+  -- ^ The list of predicates (with names) to check.
+  -> Conc.ConcIO a
+  -- ^ The computation to test.
+  -> Test
+testDejafusDiscard = testconc
+
 
 -------------------------------------------------------------------------------
 -- Refinement property testing

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             1.0.0.0
+version:             1.0.1.0
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-1.0.0.0
+  tag:      hunit-dejafu-1.0.1.0
 
 library
   exposed-modules:     Test.HUnit.DejaFu

--- a/tasty-dejafu/CHANGELOG.markdown
+++ b/tasty-dejafu/CHANGELOG.markdown
@@ -7,12 +7,18 @@ This project is versioned according to the [Package Versioning Policy](https://p
 *de facto* standard Haskell versioning scheme.
 
 
-unreleased
-----------
+1.0.1.0
+-------
+
+- **Date**    2018-02-13
+- **Git tag** [tasty-dejafu-1.0.1.0][]
+- **Hackage** https://hackage.haskell.org/package/tasty-dejafu-1.0.1.0
 
 ### Test.Tasty.DejaFu
 
 - New `testDejafusDiscard` function (#195).
+
+[tasty-dejafu-1.0.1.0]: https://github.com/barrucadu/dejafu/releases/tag/tasty-dejafu-1.0.1.0
 
 
 ---------------------------------------------------------------------------------------------------

--- a/tasty-dejafu/CHANGELOG.markdown
+++ b/tasty-dejafu/CHANGELOG.markdown
@@ -7,6 +7,17 @@ This project is versioned according to the [Package Versioning Policy](https://p
 *de facto* standard Haskell versioning scheme.
 
 
+unreleased
+----------
+
+### Test.Tasty.DejaFu
+
+- New `testDejafusDiscard` function (#195).
+
+
+---------------------------------------------------------------------------------------------------
+
+
 1.0.0.1
 -------
 

--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -250,7 +250,7 @@ testDejafusWay = testconc (const Nothing)
 -- | Variant of 'testDejafusWay' which can selectively discard
 -- results, beyond what each predicate already discards.
 --
--- @since unreleased
+-- @since 1.0.1.0
 testDejafusDiscard :: Show b
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.

--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -247,7 +247,8 @@ testDejafusWay :: Show b
   -> TestTree
 testDejafusWay = testconc (const Nothing)
 
--- | Variant of 'testDejafusWay' which can selectively discard results.
+-- | Variant of 'testDejafusWay' which can selectively discard
+-- results, beyond what each predicate already discards.
 --
 -- @since unreleased
 testDejafusDiscard :: Show b

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             1.0.0.1
+version:             1.0.1.0
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-1.0.0.1
+  tag:      tasty-dejafu-1.0.1.0
 
 library
   exposed-modules:     Test.Tasty.DejaFu


### PR DESCRIPTION
## Summary

- Adds `testDejafusDiscard` (from #195) to `hunit-dejafu` as well
- Clarifies what the discard function does in this context
- Adds CHANGELOG entries
- Prepares a release