### PR TITLE
Check some error conditions for threads and throw

### DIFF
--- a/dejafu/Test/DejaFu/Conc/Internal.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal.hs
@@ -195,7 +195,7 @@ stepThread sched memtype tid action ctx = case action of
 
     -- check if the current thread is bound
     AIsBound c ->
-      let isBound = isJust (_bound =<< M.lookup tid (cThreads ctx))
+      let isBound = isJust . _bound $ elookup "stepThread.AIsBound" tid (cThreads ctx)
       in simple (goto (c isBound) tid (cThreads ctx)) (IsCurrentThreadBound isBound)
 
     -- get the 'ThreadId' of the current thread

--- a/dejafu/Test/DejaFu/Conc/Internal.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal.hs
@@ -370,7 +370,7 @@ stepThread sched memtype tid action ctx = case action of
     -- a function to run a computation with the current masking state.
     AMasking m ma c ->
       let a = runCont (ma umask) (AResetMask False False m' . c)
-          m' = _masking . efromJust "stepThread.AMasking" $ M.lookup tid (cThreads ctx)
+          m' = _masking $ elookup "stepThread.AMasking" tid (cThreads ctx)
           umask mb = resetMask True m' >> mb >>= \b -> resetMask False m >> pure b
           resetMask typ ms = cont $ \k -> AResetMask typ True ms $ k ()
           threads' = goto a tid (mask m tid (cThreads ctx))

--- a/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
@@ -131,7 +131,7 @@ goto a = eadjust "goto" $ \thread -> thread { _continuation = a }
 -- from the parent thread. This ID must not already be in use!
 launch :: ThreadId -> ThreadId -> ((forall b. M n r b -> M n r b) -> Action n r) -> Threads n r -> Threads n r
 launch parent tid a threads = launch' ms tid a threads where
-  ms = maybe Unmasked _masking (M.lookup parent threads)
+  ms = _masking (elookup "launch" parent threads)
 
 -- | Start a thread with the given ID and masking state. This must not already be in use!
 launch' :: MaskingState -> ThreadId -> ((forall b. M n r b -> M n r b) -> Action n r) -> Threads n r -> Threads n r

--- a/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
@@ -181,13 +181,10 @@ makeBound tid threads = do
 --
 -- If the thread is bound, the worker thread is cleaned up.
 kill :: C.MonadConc n => ThreadId -> Threads n r -> n (Threads n r)
-kill tid threads = case M.lookup tid threads of
-  Just thread -> case _bound thread of
-    Just bt -> do
-      C.killThread (_boundTId bt)
-      pure (M.delete tid threads)
-    Nothing -> pure (M.delete tid threads)
-  Nothing -> pure threads
+kill tid threads = do
+  let thread = elookup "kill" tid threads
+  maybe (pure ()) (C.killThread . _boundTId) (_bound thread)
+  pure (M.delete tid threads)
 
 -- | Run an action.
 --

--- a/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
@@ -16,6 +16,7 @@ module Test.DejaFu.Conc.Internal.Threading where
 import qualified Control.Concurrent.Classy        as C
 import           Control.Exception                (Exception, MaskingState(..),
                                                    SomeException, fromException)
+import           Control.Monad                    (forever)
 import           Data.List                        (intersect)
 import           Data.Map.Strict                  (Map)
 import qualified Data.Map.Strict                  as M
@@ -170,12 +171,9 @@ makeBound tid threads = do
     let bt = BoundThread runboundIO getboundIO btid
     pure (eadjust "makeBound" (\t -> t { _bound = Just bt }) tid threads)
   where
-    go runboundIO getboundIO =
-      let loop = do
-            na <- C.takeMVar runboundIO
-            C.putMVar getboundIO =<< na
-            loop
-      in loop
+    go runboundIO getboundIO = forever $ do
+      na <- C.takeMVar runboundIO
+      C.putMVar getboundIO =<< na
 
 -- | Kill a thread and remove it from the thread map.
 --

--- a/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
@@ -135,7 +135,7 @@ launch parent tid a threads = launch' ms tid a threads where
 
 -- | Start a thread with the given ID and masking state. This must not already be in use!
 launch' :: MaskingState -> ThreadId -> ((forall b. M n r b -> M n r b) -> Action n r) -> Threads n r -> Threads n r
-launch' ms tid a = M.insert tid thread where
+launch' ms tid a = einsert "launch'" tid thread where
   thread = Thread (a umask) Nothing [] ms Nothing
 
   umask mb = resetMask True Unmasked >> mb >>= \b -> resetMask False ms >> pure b

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -336,6 +336,13 @@ einsert src k v m
   | M.member k m = fatal src ("insert: key '" ++ show k ++ "' already present")
   | otherwise = M.insert k v m
 
+-- | 'M.lookup' but which errors if the key is not present.  Use this
+-- only where it shouldn't fail!
+elookup :: (Ord k, Show k) => String -> k -> M.Map k v -> v
+elookup src k =
+  fromMaybe (fatal src ("lookup: key '" ++ show k ++ "' not found")) .
+  M.lookup k
+
 -- | 'error' but saying where it came from
 fatal :: String -> String -> a
 fatal src msg = error ("(dejafu: " ++ src ++ ") " ++ msg)

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -329,6 +329,13 @@ eadjust src f k m = case M.lookup k m of
   Just v -> M.insert k (f v) m
   Nothing -> fatal src ("adjust: key '" ++ show k ++ "' not found")
 
+-- | 'M.insert' but which errors if the key is already present.  Use
+-- this only where it shouldn't fail!
+einsert :: (Ord k, Show k) => String -> k -> v -> M.Map k v -> M.Map k v
+einsert src k v m
+  | M.member k m = fatal src ("insert: key '" ++ show k ++ "' already present")
+  | otherwise = M.insert k v m
+
 -- | 'error' but saying where it came from
 fatal :: String -> String -> a
 fatal src msg = error ("(dejafu: " ++ src ++ ") " ++ msg)

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -14,6 +14,7 @@ module Test.DejaFu.Internal where
 import           Control.DeepSeq    (NFData(..))
 import           Control.Monad.Ref  (MonadRef(..))
 import           Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.Map.Strict    as M
 import           Data.Maybe         (fromMaybe)
 import           Data.Set           (Set)
 import qualified Data.Set           as S
@@ -320,6 +321,13 @@ efromJust src _ = fatal src "fromJust: Nothing"
 efromList :: String -> [a] -> NonEmpty a
 efromList _ (x:xs) = x:|xs
 efromList src _ = fatal src "fromList: empty list"
+
+-- | 'M.adjust' but which errors if the key is not present.  Use this
+-- only where it shouldn't fail!
+eadjust :: (Ord k, Show k) => String -> (v -> v) -> k -> M.Map k v -> M.Map k v
+eadjust src f k m = case M.lookup k m of
+  Just v -> M.insert k (f v) m
+  Nothing -> fatal src ("adjust: key '" ++ show k ++ "' not found")
 
 -- | 'error' but saying where it came from
 fatal :: String -> String -> a


### PR DESCRIPTION
## Summary

Checks a bunch of error conditions around threading and calls `fatal` with some sensible message.  Previously dejafu would just soldier on and end up in a weird state (although it would have to already be in a weird state to start with).

None of the errors are raised by the tests, which is good.  I expect it would have been pretty obvious if we were (eg) creating two threads with the same ID, but it is comforting to have that explicitly checked.