### PR TITLE
Add a testing-only 'dontCheck' function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,9 +46,9 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.4.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.0.0.2 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 1.0.1.0 | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 1.0.1.0 | Deja Fu support for the Tasty test framework. |
+| [dejafu][h:dejafu]       | 1.1.0.0 | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 1.0.1.1 | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 1.0.1.1 | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/dejafu-tests/lib/Common.hs
+++ b/dejafu-tests/lib/Common.hs
@@ -17,7 +17,7 @@ import qualified Hedgehog.Range                as HRange
 import           System.Random                 (mkStdGen)
 import           Test.DejaFu                   (Failure, Predicate,
                                                 ProPredicate(..), Result(..),
-                                                Way, alwaysTrue)
+                                                Way, alwaysTrue, somewhereTrue)
 import           Test.DejaFu.Conc              (ConcIO, Scheduler(..),
                                                 randomSched, runConcurrent)
 import           Test.DejaFu.SCT.Internal.DPOR
@@ -82,6 +82,9 @@ djfuTS name p c = toTestList $ TEST name c p defaultWays False
 
 alwaysFailsWith :: (Failure -> Bool) -> Predicate a
 alwaysFailsWith p = alwaysTrue (either p (const False))
+
+sometimesFailsWith :: (Failure -> Bool) -> Predicate a
+sometimesFailsWith p = somewhereTrue (either p (const False))
 
 testProperty :: String -> H.PropertyT IO () -> T.TestTree
 testProperty name = H.testProperty name . H.property

--- a/dejafu-tests/lib/Integration/MultiThreaded.hs
+++ b/dejafu-tests/lib/Integration/MultiThreaded.hs
@@ -282,6 +282,15 @@ hacksTests = toTestList
         putMVar trigger ()
         readCRef ref
 
+    , djfuT "Bound threads created on the inside are bound on the outside" (gives' [True]) $ do
+        (out, trigger) <- dontCheck Nothing $ do
+          v <- newEmptyMVar
+          o <- newEmptyMVar
+          _ <- forkOS (takeMVar v >> isCurrentThreadBound >>= putMVar o)
+          pure (o, v)
+        putMVar trigger ()
+        takeMVar out
+
     , djfuT "Thread IDs are consistent between the inner action and the outside" (sometimesFailsWith isUncaughtException) $ do
         (tid, trigger) <- dontCheck Nothing $ do
           me <- myThreadId

--- a/dejafu-tests/lib/Integration/MultiThreaded.hs
+++ b/dejafu-tests/lib/Integration/MultiThreaded.hs
@@ -8,7 +8,7 @@ import           Test.DejaFu               (Failure(..), gives, gives',
 
 import           Control.Concurrent.Classy
 import qualified Data.IORef                as IORef
-import           Test.DejaFu.Conc          (subconcurrency)
+import           Test.DejaFu.Conc          (dontCheck, subconcurrency)
 
 import           Common
 
@@ -20,7 +20,7 @@ tests =
   , testGroup "STM" stmTests
   , testGroup "Exceptions" exceptionTests
   , testGroup "Capabilities" capabilityTests
-  , testGroup "Subconcurrency" subconcurrencyTests
+  , testGroup "Hacks" hacksTests
   , testGroup "IO" ioTests
   ]
 
@@ -150,6 +150,11 @@ crefTests = toTestList
       b2 <- fst <$> readMVar j2
       v  <- readCRef x
       pure (b1, b2, v)
+
+  , djfuT "CRef writes may be delayed" (gives' [0,1]) $ do
+      x <- newCRefInt 0
+      writeCRef x 1
+      takeMVar =<< spawn (readCRef x)
   ]
 
 --------------------------------------------------------------------------------
@@ -231,33 +236,67 @@ capabilityTests = toTestList
 
 --------------------------------------------------------------------------------
 
-subconcurrencyTests :: [TestTree]
-subconcurrencyTests = toTestList
-  [ djfuTS "Failure is observable" (gives' [Left Deadlock, Right ()]) $ do
-      var <- newEmptyMVar
-      subconcurrency $ do
-        _ <- fork $ putMVar var ()
-        putMVar var ()
+hacksTests :: [TestTree]
+hacksTests = toTestList
+  [ testGroup "Subconcurrency"
+    [ djfuTS "Failure is observable" (gives' [Left Deadlock, Right ()]) $ do
+        var <- newEmptyMVar
+        subconcurrency $ do
+          _ <- fork $ putMVar var ()
+          putMVar var ()
 
-  , djfuTS "Failure does not abort the outer computation" (gives' [(Left Deadlock, ()), (Right (), ())]) $ do
-      var <- newEmptyMVar
-      res <- subconcurrency $ do
-        _ <- fork $ putMVar var ()
-        putMVar var ()
-      (,) <$> pure res <*> readMVar var
+    , djfuTS "Failure does not abort the outer computation" (gives' [(Left Deadlock, ()), (Right (), ())]) $ do
+        var <- newEmptyMVar
+        res <- subconcurrency $ do
+          _ <- fork $ putMVar var ()
+          putMVar var ()
+        (,) <$> pure res <*> readMVar var
 
-  , djfuTS "Success is observable" (gives' [Right ()]) $ do
-      var <- newMVar ()
-      subconcurrency $ do
-        out <- newEmptyMVar
-        _ <- fork $ takeMVar var >>= putMVar out
-        takeMVar out
+    , djfuTS "Success is observable" (gives' [Right ()]) $ do
+        var <- newMVar ()
+        subconcurrency $ do
+          out <- newEmptyMVar
+          _ <- fork $ takeMVar var >>= putMVar out
+          takeMVar out
 
-  , djfuTS "It is illegal to start subconcurrency after forking" (gives [Left IllegalSubconcurrency]) $ do
-      var <- newEmptyMVar
-      _ <- fork $ readMVar var
-      _ <- subconcurrency $ pure ()
-      pure ()
+    , djfuTS "It is illegal to start subconcurrency after forking" (gives [Left IllegalSubconcurrency]) $ do
+        var <- newEmptyMVar
+        _ <- fork $ readMVar var
+        _ <- subconcurrency $ pure ()
+        pure ()
+    ]
+
+  , testGroup "DontCheck"
+    [ djfuT "Inner action is run with a deterministic scheduler" (gives' [1]) $
+        dontCheck Nothing $ do
+          r <- newCRefInt 1
+          _ <- fork (atomicWriteCRef r 2)
+          readCRef r
+
+    , djfuT "Threads created by the inner action persist in the outside" (gives' [1,2]) $ do
+        (ref, trigger) <- dontCheck Nothing $ do
+          r <- newCRefInt 1
+          v <- newEmptyMVar
+          _ <- fork (takeMVar v >> atomicWriteCRef r 2)
+          pure (r, v)
+        putMVar trigger ()
+        readCRef ref
+
+    , djfuT "Thread IDs are consistent between the inner action and the outside" (sometimesFailsWith isUncaughtException) $ do
+        (tid, trigger) <- dontCheck Nothing $ do
+          me <- myThreadId
+          v <- newEmptyMVar
+          t <- fork $ takeMVar v >> killThread me
+          pure (t, v)
+        putMVar trigger ()
+
+    , djfuT "Inner action is run under sequential consistency" (gives' [1]) $ do
+        x <- dontCheck Nothing $ do
+          x <- newCRefInt 0
+          writeCRef x 1
+          pure x
+        takeMVar =<< spawn (readCRef x)
+    ]
   ]
 
 -------------------------------------------------------------------------------

--- a/dejafu-tests/lib/Integration/SingleThreaded.hs
+++ b/dejafu-tests/lib/Integration/SingleThreaded.hs
@@ -4,14 +4,16 @@ module Integration.SingleThreaded where
 
 import           Control.Exception         (ArithException(..),
                                             ArrayException(..))
-import           Test.DejaFu               (Failure(..), gives, gives',
+import           Test.DejaFu               (Failure(..), gives, gives', isAbort,
+                                            isDeadlock, isIllegalDontCheck,
                                             isUncaughtException)
+import           Test.DejaFu.Defaults      (defaultLengthBound)
 
 import           Control.Concurrent.Classy
 import           Control.Monad             (replicateM_)
 import           Control.Monad.IO.Class    (liftIO)
 import qualified Data.IORef                as IORef
-import           Test.DejaFu.Conc          (subconcurrency)
+import           Test.DejaFu.Conc          (dontCheck, subconcurrency)
 
 import           Common
 
@@ -22,7 +24,7 @@ tests =
   , testGroup "STM" stmTests
   , testGroup "Exceptions" exceptionTests
   , testGroup "Capabilities" capabilityTests
-  , testGroup "Subconcurrency" subconcurrencyTests
+  , testGroup "Hacks" hacksTests
   , testGroup "IO" ioTests
   ]
 
@@ -230,22 +232,48 @@ capabilityTests = toTestList
 
 --------------------------------------------------------------------------------
 
-subconcurrencyTests :: [TestTree]
-subconcurrencyTests = toTestList
-  [ djfuS "Failures in subconcurrency can be observed" (gives' [True]) $ do
-      x <- subconcurrency (newEmptyMVar >>= readMVar)
-      pure (either (==Deadlock) (const False) x)
+hacksTests :: [TestTree]
+hacksTests = toTestList
+  [ testGroup "Subconcurrency"
+    [ djfuS "Failures in subconcurrency can be observed" (gives' [True]) $ do
+        x <- subconcurrency (newEmptyMVar >>= readMVar)
+        pure (either (==Deadlock) (const False) x)
 
-  , djfuS "Actions after a failing subconcurrency still happen" (gives' [True]) $ do
-      var <- newMVarInt 0
-      x <- subconcurrency (putMVar var 1)
-      y <- readMVar var
-      pure (either (==Deadlock) (const False) x && y == 0)
+    , djfuS "Actions after a failing subconcurrency still happen" (gives' [True]) $ do
+        var <- newMVarInt 0
+        x <- subconcurrency (putMVar var 1)
+        y <- readMVar var
+        pure (either (==Deadlock) (const False) x && y == 0)
 
-  , djfuS "Non-failing subconcurrency returns the final result" (gives' [True]) $ do
-      var <- newMVarInt 3
-      x <- subconcurrency (takeMVar var)
-      pure (either (const False) (==3) x)
+    , djfuS "Non-failing subconcurrency returns the final result" (gives' [True]) $ do
+        var <- newMVarInt 3
+        x <- subconcurrency (takeMVar var)
+        pure (either (const False) (==3) x)
+    ]
+
+  , testGroup "DontCheck"
+    [ djfu "Inner state modifications are visible to the outside" (gives' [True]) $ do
+        outer <- dontCheck Nothing $ do
+          inner <- newEmptyMVarInt
+          putMVar inner 5
+          pure inner
+        (==5) <$> takeMVar outer
+
+    , djfu "Failures abort the whole computation" (alwaysFailsWith isDeadlock) $
+        dontCheck Nothing $ takeMVar =<< newEmptyMVarInt
+
+    , djfu "Must be the very first thing" (alwaysFailsWith isIllegalDontCheck) $ do
+        v <- newEmptyMVarInt
+        dontCheck Nothing $ putMVar v 5
+
+    , djfu "Exceeding the length bound aborts the whole computation" (alwaysFailsWith isAbort) $
+        dontCheck (Just 1) $ newEmptyMVarInt >> pure ()
+
+    , djfu "Only counts as one action towards SCT length bounding" (gives' [True]) $ do
+        let ntimes = fromIntegral defaultLengthBound * 5
+        dontCheck Nothing $ replicateM_ ntimes (pure ())
+        pure True
+    ]
   ]
 
 -------------------------------------------------------------------------------

--- a/dejafu-tests/lib/Integration/SingleThreaded.hs
+++ b/dejafu-tests/lib/Integration/SingleThreaded.hs
@@ -285,6 +285,29 @@ hacksTests = toTestList
             writeCRef r 2
             pure r
           readCRef r
+
+      , snapshotTest "Lifted IO is re-run (1)" (gives' [2..151]) $ do
+          r <- dontCheck Nothing $ do
+            r <- liftIO (IORef.newIORef 0)
+            liftIO (IORef.modifyIORef r (+1))
+            pure r
+          liftIO (IORef.readIORef r)
+
+      , snapshotTest "Lifted IO is re-run (2)" (gives' [1]) $ do
+          r <- dontCheck Nothing $ do
+            let modify r f = liftIO (IORef.readIORef r) >>= liftIO . IORef.writeIORef r . f
+            r <- liftIO (IORef.newIORef 0)
+            modify r (+1)
+            pure r
+          liftIO (IORef.readIORef r)
+
+      , snapshotTest "Lifted IO is re-run (3)" (gives' [1]) $ do
+          r <- dontCheck Nothing $ do
+            r <- liftIO (IORef.newIORef 0)
+            liftIO (IORef.writeIORef r 0)
+            liftIO (IORef.modifyIORef r (+1))
+            pure r
+          liftIO (IORef.readIORef r)
       ]
     ]
   ]

--- a/dejafu-tests/lib/Integration/SingleThreaded.hs
+++ b/dejafu-tests/lib/Integration/SingleThreaded.hs
@@ -13,6 +13,7 @@ import           Control.Concurrent.Classy
 import           Control.Monad             (replicateM_)
 import           Control.Monad.IO.Class    (liftIO)
 import qualified Data.IORef                as IORef
+import           System.Random             (mkStdGen)
 import           Test.DejaFu.Conc          (dontCheck, subconcurrency)
 
 import           Common
@@ -273,6 +274,18 @@ hacksTests = toTestList
         let ntimes = fromIntegral defaultLengthBound * 5
         dontCheck Nothing $ replicateM_ ntimes (pure ())
         pure True
+
+    -- we use 'randomly' here because we specifically want to compare
+    -- multiple executions with snapshotting
+    , toTestList . testGroup "Snapshotting" $ let snapshotTest n p conc = W n conc p ("randomly", randomly (mkStdGen 0) 150) in
+      [ snapshotTest "State updates are applied correctly" (gives' [2]) $ do
+          r <- dontCheck Nothing $ do
+            r <- newCRefInt 0
+            writeCRef r 1
+            writeCRef r 2
+            pure r
+          readCRef r
+      ]
     ]
   ]
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -24,9 +24,16 @@ Added
 * (:pull:`219`) A snapshotting approach based on
   ``Test.DejaFu.Conc.dontCheck``:
 
-    * ``Test.DejaFu.Conc.canDCSnapshot``
     * ``Test.DejaFu.Conc.runForDCSnapshot``
     * ``Test.DejaFu.Conc.runWithDCSnapshot``
+    * ``Test.DejaFu.Conc.canDCSnapshot``
+    * ``Test.DejaFu.Conc.threadsFromDCSnapshot``
+
+Changed
+~~~~~~~
+
+* (:pull:`219`) SCT functions automatically use the snapshotting
+  mechanism when possible.
 
 
 1.0.0.2 (2018-02-18)

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -21,6 +21,13 @@ Added
     * ``Test.DejaFu.Types.IllegalDontCheck``
     * ``Test.DejaFu.Types.isIllegalDontCheck``
 
+* (:pull:`219`) A snapshotting approach based on
+  ``Test.DejaFu.Conc.dontCheck``:
+
+    * ``Test.DejaFu.Conc.canDCSnapshot``
+    * ``Test.DejaFu.Conc.runForDCSnapshot``
+    * ``Test.DejaFu.Conc.runWithDCSnapshot``
+
 
 1.0.0.2 (2018-02-18)
 --------------------

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,13 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.1.0.0 (2018-02-22)
+--------------------
+
+* Git: :tag:`dejafu-1.1.0.0`
+* Hackage: :hackage:`dejafu-1.1.0.0`
+
+**Contributors:** :u:`qrilka` (:pull:`228`).
 
 Added
 ~~~~~

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,21 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Added
+~~~~~
+
+* (:pull:`219`) The testing-only ``Test.DejaFu.Conc.dontCheck``
+  function, and associated definitions:
+
+    * ``Test.DejaFu.Types.DontCheck``
+    * ``Test.DejaFu.Types.WillDontCheck``
+    * ``Test.DejaFu.Types.IllegalDontCheck``
+    * ``Test.DejaFu.Types.isIllegalDontCheck``
+
+
 1.0.0.2 (2018-02-18)
 --------------------
 

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -72,8 +72,11 @@ There are two types of failure which dejafu itself may raise:
    aren't using a scheduler you wrote yourself, please [file a
    bug](https://github.com/barrucadu/dejafu/issues).
 
-Finally, there is one failure which can arise through improper use of
+Finally, there are two failures which can arise through improper use of
 dejafu:
+
+ * 'IllegalDontCheck', the "Test.DejaFu.Conc.dontCheck" function is
+   used as anything other than the fist action in the main thread.
 
  * 'IllegalSubconcurrency', the "Test.DejaFu.Conc.subconcurrency"
    function is used when multiple threads exist, or is used inside
@@ -323,6 +326,7 @@ Helper functions to identify failures.
   , isDeadlock
   , isUncaughtException
   , isIllegalSubconcurrency
+  , isIllegalDontCheck
 
   -- * Property testing
 

--- a/dejafu/Test/DejaFu/Conc.hs
+++ b/dejafu/Test/DejaFu/Conc.hs
@@ -278,7 +278,7 @@ subconcurrency ma = toConc (ASub (unC ma))
 -- If the action fails (deadlock, length bound exceeded, etc), the
 -- whole computation fails.
 --
--- @since unreleased
+-- @since 1.1.0.0
 dontCheck
   :: Maybe Int
   -- ^ An optional length bound.
@@ -345,7 +345,7 @@ dontCheck lb ma = toConc (ADontCheck lb (unC ma))
 -- | A snapshot of the concurrency state immediately after 'dontCheck'
 -- finishes.
 --
--- @since unreleased
+-- @since 1.1.0.0
 data DCSnapshot r n a = DCSnapshot
   { dcsContext :: Context n r ()
   -- ^ The execution context.  The scheduler state is ignored when
@@ -367,7 +367,7 @@ data DCSnapshot r n a = DCSnapshot
 -- 'dontCheck', snapshotting will be handled for you, without you
 -- needing to call this function yourself.
 --
--- @since unreleased
+-- @since 1.1.0.0
 runForDCSnapshot :: (C.MonadConc n, MonadRef r n)
   => ConcT r n a
   -> n (Maybe (Either Failure (DCSnapshot r n a), Trace))
@@ -386,7 +386,7 @@ runForDCSnapshot ma = do
 -- 'dontCheck', snapshotting will be handled for you, without you
 -- needing to call this function yourself.
 --
--- @since unreleased
+-- @since 1.1.0.0
 runWithDCSnapshot :: (C.MonadConc n, MonadRef r n)
   => Scheduler s
   -> MemType
@@ -406,14 +406,14 @@ runWithDCSnapshot sched memtype s snapshot = do
 
 -- | Check if a 'DCSnapshot' can be taken from this computation.
 --
--- @since unreleased
+-- @since 1.1.0.0
 canDCSnapshot :: ConcT r n a -> Bool
 canDCSnapshot (C (M k)) = lookahead (k undefined) == WillDontCheck
 
 -- | Get the threads which exist in a snapshot, partitioned into
 -- runnable and not runnable.
 --
--- @since unreleased
+-- @since 1.1.0.0
 threadsFromDCSnapshot :: DCSnapshot r n a -> ([ThreadId], [ThreadId])
 threadsFromDCSnapshot snapshot = partition isRunnable (M.keys threads) where
   threads = cThreads (dcsContext snapshot)

--- a/dejafu/Test/DejaFu/Conc.hs
+++ b/dejafu/Test/DejaFu/Conc.hs
@@ -248,8 +248,7 @@ runConcurrent sched memtype s ma = do
 subconcurrency :: ConcT r n a -> ConcT r n (Either Failure a)
 subconcurrency ma = toConc (ASub (unC ma))
 
--- | Run an arbitrary action which is invisible for the purposes of
--- systematic testing and bounding:
+-- | Run an arbitrary action which gets some special treatment:
 --
 --  * For systematic testing, 'dontCheck' is not dependent with
 --    anything, even if the action has dependencies.
@@ -263,6 +262,10 @@ subconcurrency ma = toConc (ASub (unC ma))
 --
 --  * For length bounding, 'dontCheck' counts for one step, even if
 --    the action has many.
+--
+--   * All SCT functions use 'runForDCSnapshot' / 'runWithDCSnapshot'
+--     to ensure that the action is only executed once, although you
+--     should be careful with @IO@ (see note on snapshotting @IO@).
 --
 -- The action is executed atomically with a deterministic scheduler
 -- under sequential consistency.  Any threads created inside the

--- a/dejafu/Test/DejaFu/Conc/Internal/Common.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Common.hs
@@ -151,6 +151,7 @@ data Action n r =
 
   | forall a. ASub (M n r a) (Either Failure a -> Action n r)
   | AStopSub (Action n r)
+  | forall a. ADontCheck (Maybe Int) (M n r a) (a -> Action n r)
 
 --------------------------------------------------------------------------------
 -- * Scheduling & Traces
@@ -192,3 +193,4 @@ lookahead (AReturn _) = WillReturn
 lookahead (AStop _) = WillStop
 lookahead (ASub _ _) = WillSubconcurrency
 lookahead (AStopSub _) = WillStopSubconcurrency
+lookahead (ADontCheck _ _ _) = WillDontCheck

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -167,6 +167,7 @@ rewind Return = Just WillReturn
 rewind Stop = Just WillStop
 rewind Subconcurrency = Just WillSubconcurrency
 rewind StopSubconcurrency = Just WillStopSubconcurrency
+rewind (DontCheck _) = Just WillDontCheck
 
 -- | Check if an operation could enable another thread.
 willRelease :: Lookahead -> Bool
@@ -184,6 +185,7 @@ willRelease WillThrow = True
 willRelease (WillSetMasking _ _) = True
 willRelease (WillResetMasking _ _) = True
 willRelease WillStop = True
+willRelease WillDontCheck = True
 willRelease _ = False
 
 -------------------------------------------------------------------------------

--- a/dejafu/Test/DejaFu/SCT.hs
+++ b/dejafu/Test/DejaFu/SCT.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 
 -- |
 -- Module      : Test.DejaFu.SCT
@@ -8,7 +9,7 @@
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
--- Portability : BangPatterns, GADTs, GeneralizedNewtypeDeriving
+-- Portability : BangPatterns, GADTs, GeneralizedNewtypeDeriving, LambdaCase
 --
 -- Systematic testing for concurrent computations.
 module Test.DejaFu.SCT
@@ -498,30 +499,18 @@ sctBoundDiscard :: (MonadConc n, MonadRef r n)
   -> ConcT r n a
   -- ^ The computation to run many times
   -> n [(Either Failure a, Trace)]
-sctBoundDiscard discard memtype cb conc = go initialState where
-  -- Repeatedly run the computation gathering all the results and
-  -- traces into a list until there are no schedules remaining to try.
-  go !dp = case findSchedulePrefix dp of
-    Just (prefix, conservative, sleep) -> do
-      (res, s, trace) <- runConcurrent scheduler
-                                       memtype
-                                       (initialDPORSchedState sleep prefix)
-                                       conc
+sctBoundDiscard discard0 memtype0 cb0 = sct initialState findSchedulePrefix step discard0 memtype0 where
+  step dp (prefix, conservative, sleep) run = do
+    (res, s, trace) <- run
+      (dporSched (cBound cb0))
+      (initialDPORSchedState sleep prefix)
 
-      let bpoints = findBacktracks (schedBoundKill s) (schedBPoints s) trace
-      let newDPOR = incorporateTrace conservative trace dp
+    let bpoints = findBacktrackSteps (cBacktrack cb0) (schedBoundKill s) (schedBPoints s) trace
+    let newDPOR = incorporateTrace conservative trace dp
 
-      if schedIgnore s
-        then go (force newDPOR)
-        else checkDiscard discard res trace $ go (force (incorporateBacktrackSteps bpoints newDPOR))
-
-    Nothing -> pure []
-
-  -- The DPOR scheduler.
-  scheduler = dporSched (cBound cb)
-
-  -- Find the new backtracking steps.
-  findBacktracks = findBacktrackSteps (cBacktrack cb)
+    pure $ if schedIgnore s
+           then (force newDPOR, Nothing)
+           else (force (incorporateBacktrackSteps bpoints newDPOR), Just (res, trace))
 
 -- | SCT via uniform random scheduling.
 --
@@ -561,14 +550,15 @@ sctUniformRandomDiscard :: (MonadConc n, MonadRef r n, RandomGen g)
   -> ConcT r n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
-sctUniformRandomDiscard discard memtype g0 lim0 conc = go g0 (max 0 lim0) where
-  go _ 0 = pure []
-  go g n = do
-    (res, s, trace) <- runConcurrent (randSched $ \g' -> (1, g'))
-                                     memtype
-                                     (initialRandSchedState Nothing g)
-                                     conc
-    checkDiscard discard res trace $ go (schedGen s) (n-1)
+sctUniformRandomDiscard discard0 memtype0 g0 lim0 = sct (g0, max 0 lim0) check step discard0 memtype0 where
+  check (_, 0) = Nothing
+  check s = Just s
+
+  step _ (g, n) run = do
+    (res, s, trace) <- run
+      (randSched $ \g' -> (1, g'))
+      (initialRandSchedState Nothing g)
+    pure ((schedGen s, n-1), Just (res, trace))
 
 -- | SCT via weighted random scheduling.
 --
@@ -612,15 +602,40 @@ sctWeightedRandomDiscard :: (MonadConc n, MonadRef r n, RandomGen g)
   -> ConcT r n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
-sctWeightedRandomDiscard discard memtype g0 lim0 use0 conc = go g0 (max 0 lim0) (max 1 use0) M.empty where
-  go _ 0 _ _ = pure []
-  go g n 0 _ = go g n (max 1 use0) M.empty
-  go g n use ws = do
-    (res, s, trace) <- runConcurrent (randSched $ randomR (1, 50))
-                                     memtype
-                                     (initialRandSchedState (Just ws) g)
-                                     conc
-    checkDiscard discard res trace $ go (schedGen s) (n-1) (use-1) (schedWeights s)
+sctWeightedRandomDiscard discard0 memtype0 g0 lim0 use0 = sct (g0, max 0 lim0, max 1 use0, M.empty) check step discard0 memtype0 where
+  check (_, 0, _, _) = Nothing
+  check s = Just s
+
+  step s (g, n, 0, _) run = step s (g, n, max 1 use0, M.empty) run
+  step _ (g, n, use, ws) run = do
+    (res, s, trace) <- run
+      (randSched $ randomR (1, 50))
+      (initialRandSchedState (Just ws) g)
+    pure ((schedGen s, n-1, use-1, schedWeights s), Just (res, trace))
+
+-- | General-purpose SCT function.
+sct :: (MonadConc n, MonadRef r n)
+  => s
+  -- ^ Initial state
+  -> (s -> Maybe t)
+  -- ^ State predicate
+  -> (s -> t -> (Scheduler g -> g -> n (Either Failure a, g, Trace)) -> n (s, Maybe (Either Failure a, Trace)))
+  -- ^ Run the computation and update the state
+  -> (Either Failure a -> Maybe Discard)
+  -> MemType
+  -> ConcT r n a
+  -> n [(Either Failure a, Trace)]
+sct s0 sfun srun discard memtype conc = go s0 where
+  go !s = case sfun s of
+    Just t -> srun s t run >>= \case
+      (s', Just (res, trace)) -> case discard res of
+        Just DiscardResultAndTrace -> go s'
+        Just DiscardTrace -> ((res, []):) <$> go s'
+        Nothing -> ((res, trace):) <$> go s'
+      (s', Nothing) -> go s'
+    Nothing -> pure []
+
+  run sched s = runConcurrent sched memtype s conc
 
 -------------------------------------------------------------------------------
 -- Utilities
@@ -678,10 +693,3 @@ maxDiff = go 0 where
     in go m' xs
   go m [] = m
   go' x0 m x = m `max` abs (x0 - x)
-
--- | Apply the discard function.
-checkDiscard :: Functor f => (a -> Maybe Discard) -> a -> [b] -> f [(a, [b])] -> f [(a, [b])]
-checkDiscard discard res trace rest = case discard res of
-  Just DiscardResultAndTrace -> rest
-  Just DiscardTrace -> ((res, []):) <$> rest
-  Nothing -> ((res, trace):) <$> rest

--- a/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
@@ -122,15 +122,19 @@ instance NFData BacktrackStep where
 
 -- | Initial DPOR state, given an initial thread ID. This initial
 -- thread should exist and be runnable at the start of execution.
-initialState :: DPOR
-initialState = DPOR
-  { dporRunnable = S.singleton initialThread
-  , dporTodo     = M.singleton initialThread False
-  , dporNext     = Nothing
-  , dporDone     = S.empty
-  , dporSleep    = M.empty
-  , dporTaken    = M.empty
-  }
+--
+-- The main thread must be in the list of initially runnable threads.
+initialState :: [ThreadId] -> DPOR
+initialState threads
+  | initialThread `elem` threads = DPOR
+    { dporRunnable = S.fromList threads
+    , dporTodo     = M.singleton initialThread False
+    , dporNext     = Nothing
+    , dporDone     = S.empty
+    , dporSleep    = M.empty
+    , dporTaken    = M.empty
+    }
+  | otherwise = fatal "initialState" "Initial thread is not in initially runnable set"
 
 -- | Produce a new schedule prefix from a @DPOR@ tree. If there are no new
 -- prefixes remaining, return 'Nothing'. Also returns whether the

--- a/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
@@ -568,6 +568,8 @@ independent ds t1 a1 t2 a2
     | check t2 a2 t1 a1 = False
     | otherwise = not (dependent ds t1 a1 t2 a2)
   where
+    -- @dontCheck@ must be the first thing in the computation.
+    check _ (DontCheck _) _ _ = True
     -- can't re-order any action of a thread with the fork which
     -- created it.
     check _ (Fork t) tid _ | t == tid = True

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -85,7 +85,7 @@ initialThread = ThreadId (Id (Just "main") 0)
 
 -- | All the actions that a thread can perform.
 --
--- @since unreleased
+-- @since 1.1.0.0
 data ThreadAction =
     Fork ThreadId
   -- ^ Start a new thread.
@@ -216,7 +216,7 @@ instance NFData ThreadAction where
 
 -- | A one-step look-ahead at what a thread will do next.
 --
--- @since unreleased
+-- @since 1.1.0.0
 data Lookahead =
     WillFork
   -- ^ Will start a new thread.
@@ -395,7 +395,7 @@ instance NFData Decision where
 -- The @Eq@, @Ord@, and @NFData@ instances compare/evaluate the
 -- exception with @show@ in the @UncaughtException@ case.
 --
--- @since unreleased
+-- @since 1.1.0.0
 data Failure
   = InternalError
   -- ^ Will be raised if the scheduler does something bad. This should
@@ -485,7 +485,7 @@ isIllegalSubconcurrency _ = False
 
 -- | Check if a failure is an @IllegalDontCheck@
 --
--- @since unreleased
+-- @since 1.1.0.0
 isIllegalDontCheck :: Failure -> Bool
 isIllegalDontCheck IllegalDontCheck = True
 isIllegalDontCheck _ = False

--- a/dejafu/Test/DejaFu/Utils.hs
+++ b/dejafu/Test/DejaFu/Utils.hs
@@ -81,6 +81,7 @@ showFail STMDeadlock = "[stm-deadlock]"
 showFail InternalError = "[internal-error]"
 showFail (UncaughtException exc) = "[" ++ displayException exc ++ "]"
 showFail IllegalSubconcurrency = "[illegal-subconcurrency]"
+showFail IllegalDontCheck = "[illegal-dontcheck]"
 
 -------------------------------------------------------------------------------
 -- * Scheduling

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.0.0.2
+version:             1.1.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.0.0.2
+  tag:      dejafu-1.1.0.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,9 +28,9 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.4.0.0", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.0.0.2", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "1.0.1.0", "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "1.0.1.0", "Déjà Fu support for the tasty test framework"
+   ":hackage:`dejafu`",       "1.1.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "1.0.1.1", "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "1.0.1.1", "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.0.1.1 (2018-02-22)
+--------------------
+
+* Git: :tag:`hunit-dejafu-1.0.1.1`
+* Hackage: :hackage:`hunit-dejafu-1.0.1.1`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.2.
+
+
 1.0.1.0 (2018-02-13)
 --------------------
 

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             1.0.1.0
+version:             1.0.1.1
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-1.0.1.0
+  tag:      hunit-dejafu-1.0.1.1
 
 library
   exposed-modules:     Test.HUnit.DejaFu
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.8 && <5
                      , exceptions >=0.7 && <0.9
-                     , dejafu     >=1.0 && <1.1
+                     , dejafu     >=1.0 && <1.2
                      , HUnit      >=1.2 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.0.1.1 (2018-02-22)
+--------------------
+
+* Git: :tag:`tasty-dejafu-1.0.1.1`
+* Hackage: :hackage:`tasty-dejafu-1.0.1.1`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.2.
+
+
 1.0.1.0 (2018-02-13)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             1.0.1.0
+version:             1.0.1.1
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,14 +30,14 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-1.0.1.0
+  tag:      tasty-dejafu-1.0.1.1
 
 library
   exposed-modules:     Test.Tasty.DejaFu
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.8  && <5
-                     , dejafu >=1.0  && <1.1
+                     , dejafu >=1.0  && <1.2
                      , random >=1.0  && <1.2
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.1


### PR DESCRIPTION
## Summary

Adds a testing-only `dontCheck` function, as described in #203.  I'll just copy the Haddock comment to explain it:

> Run an arbitrary action which gets some special treatment:
>
>  * For systematic testing, 'dontCheck' is not dependent with
>    anything, even if the action has dependencies.
>
>  * For pre-emption bounding, 'dontCheck' counts for zero
>    pre-emptions, even if the action performs pre-emptive context
>    switches.
>
>  * For fair bounding, `dontCheck` counts for zero yields/delays,
>    even if the action performs yields or delays.
>
>  * For length bounding, `dontCheck` counts for one step, even if
>    the action has many.
>
>   * All SCT functions use `runForDCSnapshot` / `runWithDCSnapshot`
>     to ensure that the action is only executed once, although you
>     should be careful with `IO` (see note on snapshotting `IO`).
>
> The action is executed atomically with a deterministic scheduler
> under sequential consistency.  Any threads created inside the
> action continue to exist in the main computation.
>
> This must be the first thing done in the main thread.  Violating
> this condition will result in the computation failing with
> `IllegalDontCheck`.
>
> If the action fails (deadlock, length bound exceeded, etc), the
> whole computation fails.

There are a bunch of small examples in dejafu-tests, if that's unclear.  Usage is like so:

```haskell
foo = do
  x <- dontCheck optionalLengthBound inner
  outer
```

**You need to be a little careful if you use `liftIO`:**

> A snapshot captures entire state of your concurrent program: the
> state of every thread, the number of capabilities, the values of
> any `CRef`s, `MVar`s, and `TVar`s, and records any `IO` that you
> performed.
>
> When restoring a snapshot this `IO` is replayed, in order.  But the
> whole snapshotted computation is not.  So the effects of the `IO`
> take place again, but any return values are ignored.  For example,
> this program will not do what you want:
>
> ```haskell
> bad_snapshot = do
>   r <- dontCheck Nothing $ do
>     r <- liftIO (newIORef 0)
>     liftIO (modifyIORef r (+1))
>     pure r
>   liftIO (readIORef r)
> ```
>
> When the snapshot is taken, the value in the `IORef` will be 1.
> When the snapshot is restored for the first time, those `IO`
> actions will be run again, *but their return values will be
> discarded*.  The value in the `IORef` will be 2.  When the snapshot
> is restored for the second time, the value in the `IORef` will be
> 3.  And so on.
>
> To safely use `IO` in a snapshotted computation, you should either
> use actions which set the state to the final value directly, rather
> than modifying it (eg, using a combination of `liftIO . readIORef`
> and `liftIO . writeIORef` here), or reset the state to a known
> value.  Both of these approaches will work:
>
> ```haskell
> good_snapshot1 = do
>   r <- dontCheck Nothing $ do
>     let modify r f = liftIO (readIORef r) >>= liftIO . writeIORef r . f
>     r <- liftIO (newIORef 0)
>     modify r (+1)
>     pure r
>   liftIO (readIORef r)
>
> good_snapshot2 = do
>   r <- dontCheck Nothing $ do
>     r <- liftIO (newIORef 0)
>     liftIO (writeIORef r 0)
>     liftIO (modifyIORef r (+1))
>     pure r
>   liftIO (readIORef r)
> ```
>
> **In addition to the usual requirement of determinism, the combined
> `IO` effect of your snapshot must be idempotent.**

**What's the use?**  If you have a test case which involves some nontrivial set-up which you don't want to test for races (ie, you're pretty sure it's race-free), you can use `dontCheck` to do that *once* and re-use the result, without the systematic testing trying lots of different interleavings of your set-up code.

**How is this different to `subconcurrency`?** `subconcurrency` lets you do some set up, run a thing, and then inspect the result.  But there are differences:

* `subconcurrency` doesn't let you fork any threads as part of your set-up work
* `subconcurrency` doesn't stop systematic testing from exploring interleavings of your set-up work.
* `dontCheck` doesn't let you do something afterwards if execution fails.
* `subconcurrency` doesn't snapshot the result of the set-up work.

So `dontCheck` and `subconcurrency` are both partial solutions to what I want to achieve with #202.

**Related issues:** closes #203 

## Checklist

- [x] Add new tests to dejafu-tests