### PR TITLE
Support exceptions-0.9.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,9 +45,9 @@ There are a few different packages under the Déjà Fu umbrella:
 
 |   | Version | Summary |
 | - | ------- | ------- |
-| [concurrency][h:conc]    | 1.4.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.1.0.0 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 1.0.1.1 | Deja Fu support for the HUnit test framework. |
+| [concurrency][h:conc]    | 1.4.0.1 | Typeclasses, functions, and data types for concurrency and STM. |
+| [dejafu][h:dejafu]       | 1.1.0.1 | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 1.0.1.2 | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 1.0.1.1 | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.4.0.1 (2018-02-26)
+--------------------
+
+* Git: :tag:`concurrency-1.4.0.1`
+* Hackage: :hackage:`concurrency-1.4.0.1`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`exceptions` is <0.10.
+
+
 1.4.0.0 (2018-01-19)
 --------------------
 

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                concurrency
-version:             1.4.0.0
+version:             1.4.0.1
 synopsis:            Typeclasses, functions, and data types for concurrency and STM.
 
 description:
@@ -32,7 +32,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      concurrency-1.4.0.0
+  tag:      concurrency-1.4.0.1
 
 library
   exposed-modules:     Control.Monad.Conc.Class

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -58,7 +58,7 @@ library
   build-depends:       base              >=4.8  && <5
                      , array             >=0.5  && <0.6
                      , atomic-primops    >=0.8  && <0.9
-                     , exceptions        >=0.7  && <0.9
+                     , exceptions        >=0.7  && <0.10
                      , monad-control     >=1.0  && <1.1
                      , mtl               >=2.2  && <2.3
                      , stm               >=2.4  && <2.5

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,20 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.1.0.1 (2018-02-26)
+--------------------
+
+* Git: :tag:`dejafu-1.1.0.1`
+* Hackage: :hackage:`dejafu-1.1.0.1`
+
+**Contributors:** :u:`qrilka` (:pull:`229`).
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`exceptions` is <0.10.
+
+
 1.1.0.0 (2018-02-22)
 --------------------
 

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.1.0.0
+version:             1.1.0.1
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.1.0.0
+  tag:      dejafu-1.1.0.1
 
 library
   exposed-modules:     Test.DejaFu

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -60,7 +60,7 @@ library
                      , concurrency       >=1.3 && <1.5
                      , containers        >=0.5 && <0.6
                      , deepseq           >=1.1 && <2
-                     , exceptions        >=0.7 && <0.9
+                     , exceptions        >=0.7 && <0.10
                      , leancheck         >=0.6 && <0.8
                      , profunctors       >=4.0 && <6.0
                      , random            >=1.0 && <1.2

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,9 +27,9 @@ There are a few different packages under the Déjà Fu umbrella:
 .. csv-table::
    :header: "Package", "Version", "Summary"
 
-   ":hackage:`concurrency`",  "1.4.0.0", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.1.0.0", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "1.0.1.1", "Déjà Fu support for the HUnit test framework"
+   ":hackage:`concurrency`",  "1.4.0.1", "Typeclasses, functions, and data types for concurrency and STM"
+   ":hackage:`dejafu`",       "1.1.0.1", "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "1.0.1.2", "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "1.0.1.1", "Déjà Fu support for the tasty test framework"
 
 

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.0.1.2 (2018-02-26)
+--------------------
+
+* Git: :tag:`hunit-dejafu-1.0.1.2`
+* Hackage: :hackage:`hunit-dejafu-1.0.1.2`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`exceptions` is <0.10.
+
+
 1.0.1.1 (2018-02-22)
 --------------------
 

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -37,7 +37,7 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base       >=4.8 && <5
-                     , exceptions >=0.7 && <0.9
+                     , exceptions >=0.7 && <0.10
                      , dejafu     >=1.0 && <1.2
                      , HUnit      >=1.2 && <1.7
   -- hs-source-dirs:      

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             1.0.1.1
+version:             1.0.1.2
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-1.0.1.1
+  tag:      hunit-dejafu-1.0.1.2
 
 library
   exposed-modules:     Test.HUnit.DejaFu


### PR DESCRIPTION
## Summary

Bump upper bounds of `exceptions` and prepare for an immediate release.

The `MonadMask` instance for `ConcT r n` now has an implementation of `generalBracket`.  In general, bracketing and suchlike is unsafe for continuation-based monads, but I don't think I've introduced any extra unsafety here, as the continuations remain hidden beneath the abstraction.

**Related issues:** https://github.com/fpco/stackage/issues/3315