### PR TITLE
Don't build tags on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: false
 
 language: c
 
+# If something is tagged, it's come from a PR which has been merged
+# into master.  There's no need to build both the tag and the merge
+# commit.
+if: tag IS blank
+
 # Cache builds
 cache:
   directories:


### PR DESCRIPTION
## Summary

As I've switched to doing everything (even something this small!) through PRs, there's no point in building tags on Travis.

Releases are prepared like so:

1. Set up the release metadata on a branch
2. PR that branch
3. Merge that PR when Travis is happy and after reviewing
4. Tag the merge commit
5. Push the tags

The merge commit will be built on Travis (also the head commit and the PR, so there's still some redundancy here if the branch is up to date with master).  There's no point in building the tags also.

Extreme example is 5045c31, which got built six times: the head commit, the PR, the merge commit, the three tags.

If a branch is behind master, then building the merge commit is still handy, as it could reveal a post-merge bug.  I don't want to force contributors to rebase, so we can't just turn off builds of master too.