### PR TITLE
Clarify dontCheck and subconcurrency haddocks

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.4.0.1 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.1.0.1 | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 1.1.0.2 | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 1.0.1.2 | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 1.0.1.1 | Deja Fu support for the Tasty test framework. |
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,20 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.1.0.2 (2018-03-01)
+--------------------
+
+* Git: :tag:`dejafu-1.1.0.2`
+* Hackage: :hackage:`dejafu-1.1.0.2`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* (:pull:`235`) The documentation for ``Test.DejaFu.Conc.dontCheck``
+  and ``subconcurrency`` clarify that an illegal use does not
+  necessarily cause a failing test.
+
+
 1.1.0.1 (2018-02-26)
 --------------------
 

--- a/dejafu/Test/DejaFu/Conc.hs
+++ b/dejafu/Test/DejaFu/Conc.hs
@@ -252,6 +252,8 @@ runConcurrent sched memtype s ma = do
 -- exist. Calls to 'subconcurrency' cannot be nested, or placed inside
 -- a call to 'dontCheck'. Violating either of these conditions will
 -- result in the computation failing with @IllegalSubconcurrency@.
+-- The overall test-case can still succeed if the predicate allows for
+-- a failing computation.
 --
 -- @since 0.6.0.0
 subconcurrency :: ConcT r n a -> ConcT r n (Either Failure a)
@@ -282,7 +284,8 @@ subconcurrency ma = toConc (ASub (unC ma))
 --
 -- This must be the first thing done in the main thread.  Violating
 -- this condition will result in the computation failing with
--- @IllegalDontCheck@.
+-- @IllegalDontCheck@.  The overall test-case can still succeed if the
+-- predicate allows for a failing computation.
 --
 -- If the action fails (deadlock, length bound exceeded, etc), the
 -- whole computation fails.

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.1.0.1
+version:             1.1.0.2
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.1.0.1
+  tag:      dejafu-1.1.0.2
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.4.0.1", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.1.0.1", "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "1.1.0.2", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "1.0.1.2", "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "1.0.1.1", "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
## Summary

An illegal use of `dontCheck` or `subconcurrency` doesn't necessarily cause a test case to fail.  For instance, `pure () >> dontCheck (pure ())` is totally deterministic and so will pass `alwaysSame`.  Clarify this in the haddocks.

@aherrmann This is essentially your wording, but do you agree this is better?

**Related issues:** #230 