### PR TITLE
Add missing setNumCapabilities dependency

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.4.0.1 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.3.0.1 | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 1.3.0.2 | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 1.1.0.1 | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 1.1.0.1 | Deja Fu support for the Tasty test framework. |
 

--- a/dejafu-tests/lib/Integration/Regressions.hs
+++ b/dejafu-tests/lib/Integration/Regressions.hs
@@ -65,4 +65,10 @@ tests = toTestList
       t <- mask $ \restore -> fork (try (restore (act s)) >> pure ())
       killThread t
       tryReadMVar s
+
+  , djfu "https://github.com/barrucadu/dejafu/issues/243" (gives' [1,2,3]) $ do
+      setNumCapabilities 1
+      _ <- fork (setNumCapabilities 2)
+      _ <- fork (setNumCapabilities 3)
+      getNumCapabilities
   ]

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,13 +6,16 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
-unreleased
-----------
+1.3.0.2 (2018-03-11)
+--------------------
+
+* Git: :tag:`dejafu-1.3.0.2`
+* Hackage: :hackage:`dejafu-1.3.0.2`
 
 Fixed
 ~~~~~
 
-* (:issue:`243`) Add missing dependency for ``setNumCapabilities``
+* (:pull:`244`) Add missing dependency for ``setNumCapabilities``
   actions.
 
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,6 +6,16 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+unreleased
+----------
+
+Fixed
+~~~~~
+
+* (:issue:`243`) Add missing dependency for ``setNumCapabilities``
+  actions.
+
+
 1.3.0.1 (2018-03-08)
 --------------------
 

--- a/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
@@ -641,11 +641,11 @@ dependent' ds t1 a1 t2 l2 = case (a1, l2) of
   (STM _ _, WillSTM) -> True
   (BlockedSTM _, WillSTM) -> True
 
-  -- This is a bit pessimistic: Set/Get are only dependent if the
-  -- value set is not the same as the value that will be got, but we
-  -- can't know that here. 'dependent' optimises this case.
+  -- the number of capabilities is essentially a global shared
+  -- variable
   (GetNumCapabilities _, WillSetNumCapabilities _) -> True
   (SetNumCapabilities _, WillGetNumCapabilities)   -> True
+  (SetNumCapabilities _, WillSetNumCapabilities _) -> True
 
   _ -> dependentActions ds (simplifyAction a1) (simplifyLookahead l2)
 

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.3.0.1
+version:             1.3.0.2
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.3.0.1
+  tag:      dejafu-1.3.0.2
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.4.0.1", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.3.0.1", "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "1.3.0.2", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "1.1.0.1", "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "1.1.0.1", "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
## Summary

Adds a missing dependency for `setNumCapabilities`.  The regression test doesn't reveal this *directly*, all results get found due to the dependency between `set` and `get`, but it is revealed in the dependency function test when those `set`s are swapped.

Also did some tidying of the dependency functions while I was poking around.  It now more closely matches my thesis, and is easier to read and more "obviously correct" (I think).

**Related issues:** Closes #243

## Checklist

**If this is fixing a bug or adding a feature:**

- [x] Add new tests to dejafu-tests