### PR TITLE
Refactoring

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,9 +46,9 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.4.0.2 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.3.2.0 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 1.1.0.2 | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 1.1.0.1 | Deja Fu support for the Tasty test framework. |
+| [dejafu][h:dejafu]       | 1.4.0.0 | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 1.1.0.3 | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 1.1.0.2 | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/dejafu-tests/lib/Common.hs
+++ b/dejafu-tests/lib/Common.hs
@@ -126,7 +126,7 @@ prop_dep_fun conc = H.property $ do
       let tids2 = toTIdTrace trc2
       pure (efa1, map fst tids1, efa2, map fst tids2)
 
-    play memtype conc s g = runConcurrent s memtype g conc
+    play memtype c s g = runConcurrent s memtype g c
 
 -------------------------------------------------------------------------------
 -- Exceptions

--- a/dejafu-tests/lib/Integration/MultiThreaded.hs
+++ b/dejafu-tests/lib/Integration/MultiThreaded.hs
@@ -306,11 +306,11 @@ hacksTests = toTestList
         takeMVar out
 
     , djfuT "Thread IDs are consistent between the inner action and the outside" (sometimesFailsWith isUncaughtException) $ do
-        (tid, trigger) <- dontCheck Nothing $ do
+        trigger <- dontCheck Nothing $ do
           me <- myThreadId
           v <- newEmptyMVar
-          t <- fork $ takeMVar v >> killThread me
-          pure (t, v)
+          _ <- fork $ takeMVar v >> killThread me
+          pure v
         putMVar trigger ()
 
     , djfuT "Inner action is run under sequential consistency" (gives' [1]) $ do

--- a/dejafu-tests/lib/Integration/SCT.hs
+++ b/dejafu-tests/lib/Integration/SCT.hs
@@ -31,7 +31,7 @@ discardTests = toTestList
         const (Just DiscardResultAndTrace)
     , check "Results failing the test are not present" [1, 2] $
         \x -> if x == Right 3 then Just DiscardResultAndTrace else Nothing
-    , testCase "No traces kept when they get discared" $ testDiscardTrace discarder testAction
+    , testCase "No traces kept when they get discared" $ testDiscardTrace testAction
     ]
   where
     check name xs f = testDejafuWithSettings (set ldiscard (Just f) defaultSettings) name (gives' xs) testAction
@@ -41,11 +41,12 @@ discardTests = toTestList
       _ <- fork $ putMVar mvar 2
       _ <- fork $ putMVar mvar 3
       readMVar mvar
+
     discarder (Right 2) = Just DiscardTrace
     discarder (Right 3) = Just DiscardResultAndTrace
     discarder  _ = Nothing
 
-    testDiscardTrace discarder action = do
+    testDiscardTrace action = do
       results <- runSCTWithSettings (set ldiscard (Just discarder) defaultSettings) action
       for_ results $ \(efa, trace) -> case discarder efa of
         Just DiscardResultAndTrace -> assertFailure "expected result to be discarded"

--- a/dejafu-tests/lib/Integration/SingleThreaded.hs
+++ b/dejafu-tests/lib/Integration/SingleThreaded.hs
@@ -288,7 +288,7 @@ hacksTests = toTestList
 
       , snapshotTest "Lifted IO is re-run (1)" (gives' [2..151]) $ do
           r <- dontCheck Nothing $ do
-            r <- liftIO (IORef.newIORef 0)
+            r <- liftIO (IORef.newIORef (0::Int))
             liftIO (IORef.modifyIORef r (+1))
             pure r
           liftIO (IORef.readIORef r)
@@ -296,14 +296,14 @@ hacksTests = toTestList
       , snapshotTest "Lifted IO is re-run (2)" (gives' [1]) $ do
           r <- dontCheck Nothing $ do
             let modify r f = liftIO (IORef.readIORef r) >>= liftIO . IORef.writeIORef r . f
-            r <- liftIO (IORef.newIORef 0)
+            r <- liftIO (IORef.newIORef (0::Int))
             modify r (+1)
             pure r
           liftIO (IORef.readIORef r)
 
       , snapshotTest "Lifted IO is re-run (3)" (gives' [1]) $ do
           r <- dontCheck Nothing $ do
-            r <- liftIO (IORef.newIORef 0)
+            r <- liftIO (IORef.newIORef (0::Int))
             liftIO (IORef.writeIORef r 0)
             liftIO (IORef.modifyIORef r (+1))
             pure r

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -153,7 +153,7 @@ memoryProps = toTestList
   where
     crefProp
       :: (Monad m, Show a)
-      => (forall s. D.CRef (ST.STRef s) Int -> ST.ST s a)
+      => (forall s. D.ModelCRef (ST.STRef s) Int -> ST.ST s a)
       -> H.PropertyT m a
     crefProp p = do
       crefId <- H.forAll genCRefId
@@ -201,8 +201,8 @@ sctProps = toTestList
 -------------------------------------------------------------------------------
 -- Utils
 
-makeCRef :: D.CRefId -> ST.ST t (D.CRef (ST.STRef t) Int)
-makeCRef crid = D.CRef crid <$> ST.newSTRef (M.empty, 0, 42)
+makeCRef :: D.CRefId -> ST.ST t (D.ModelCRef (ST.STRef t) Int)
+makeCRef crid = D.ModelCRef crid <$> ST.newSTRef (M.empty, 0, 42)
 
 -- equality for writebuffers is a little tricky as we can't directly
 -- compare the buffered values, so we compare everything else:
@@ -224,7 +224,7 @@ eqWB (Mem.WriteBuffer wb1) (Mem.WriteBuffer wb2) = andM (pure (ks1 == ks2) :
     ks1 = M.keys $ M.filter (not . S.null) wb1
     ks2 = M.keys $ M.filter (not . S.null) wb2
 
-    eqBW (Mem.BufferedWrite t1 (D.CRef crid1 ref1) _) (Mem.BufferedWrite t2 (D.CRef crid2 ref2) _) = do
+    eqBW (Mem.BufferedWrite t1 (D.ModelCRef crid1 ref1) _) (Mem.BufferedWrite t2 (D.ModelCRef crid2 ref2) _) = do
       d1 <- (\(m,i,_) -> (M.keys m, i)) <$> ST.readSTRef ref1
       d2 <- (\(m,i,_) -> (M.keys m, i)) <$> ST.readSTRef ref2
       pure (t1 == t2 && crid1 == crid2 && d1 == d2)

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -5,7 +5,6 @@ import qualified Control.Exception                as E
 import           Control.Monad                    (zipWithM)
 import qualified Control.Monad.Conc.Class         as C
 import           Control.Monad.IO.Class           (liftIO)
-import qualified Control.Monad.ST                 as ST
 import qualified Data.Foldable                    as F
 import qualified Data.Map                         as M
 import qualified Data.Sequence                    as S

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,24 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Changed
+~~~~~~~
+
+- (:issue:`201`) ``Test.DejaFu.Conc.ConcT r n a`` drops its ``r``
+  parameter, becoming ``ConcT n a``.
+
+- (:issue:`201`) All functions drop the ``MonadConc`` constraint.
+
+Removed
+~~~~~~~
+
+- (:issue:`201`) The ``MonadRef`` and ``MonadAtomicRef`` instances for
+  ``Test.DejaFu.Conc.ConcT``.
+
+
 1.3.2.0 (2018-03-12)
 --------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.4.0.0 (2018-03-17)
+--------------------
+
+* Git: :tag:`dejafu-1.4.0.0`
+* Hackage: :hackage:`dejafu-1.4.0.0`
 
 Changed
 ~~~~~~~

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -24,6 +24,9 @@ Removed
 - (:issue:`201`) The ``MonadRef`` and ``MonadAtomicRef`` instances for
   ``Test.DejaFu.Conc.ConcT``.
 
+- (:issue:`198`) The ``Test.DejaFu.Types.Killed`` thread action, which
+  was unused.
+
 
 1.3.2.0 (2018-03-12)
 --------------------

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -27,6 +27,11 @@ Removed
 - (:issue:`198`) The ``Test.DejaFu.Types.Killed`` thread action, which
   was unused.
 
+Fixed
+~~~~~
+
+- (:issue:`250`) Add missing dependency for ``throwTo`` actions.
+
 
 1.3.2.0 (2018-03-12)
 --------------------

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TupleSections #-}
 
 {- |
@@ -273,7 +272,6 @@ import           Control.DeepSeq          (NFData(..))
 import           Control.Monad            (unless, when)
 import           Control.Monad.Conc.Class (MonadConc)
 import           Control.Monad.IO.Class   (MonadIO(..))
-import           Control.Monad.Ref        (MonadRef)
 import           Data.Function            (on)
 import           Data.List                (intercalate, intersperse)
 import           Data.Maybe               (catMaybes, isJust, isNothing,
@@ -329,8 +327,8 @@ let relaxed = do
 -- False
 --
 -- @since 1.0.0.0
-autocheck :: (MonadConc n, MonadIO n, MonadRef r n, Eq a, Show a)
-  => ConcT r n a
+autocheck :: (MonadConc n, MonadIO n, Eq a, Show a)
+  => ConcT n a
   -- ^ The computation to test.
   -> n Bool
 autocheck = autocheckWithSettings defaultSettings
@@ -363,12 +361,12 @@ autocheck = autocheckWithSettings defaultSettings
 -- False
 --
 -- @since 1.0.0.0
-autocheckWay :: (MonadConc n, MonadIO n, MonadRef r n, Eq a, Show a)
+autocheckWay :: (MonadConc n, MonadIO n, Eq a, Show a)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
 autocheckWay way = autocheckWithSettings . fromWayAndMemType way
@@ -400,10 +398,10 @@ autocheckWay way = autocheckWithSettings . fromWayAndMemType way
 -- False
 --
 -- @since 1.2.0.0
-autocheckWithSettings :: (MonadConc n, MonadIO n, MonadRef r n, Eq a, Show a)
+autocheckWithSettings :: (MonadConc n, MonadIO n, Eq a, Show a)
   => Settings n a
   -- ^ The SCT settings.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
 autocheckWithSettings settings = dejafusWithSettings settings
@@ -427,12 +425,12 @@ autocheckWithSettings settings = dejafusWithSettings settings
 -- False
 --
 -- @since 1.0.0.0
-dejafu :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
+dejafu :: (MonadConc n, MonadIO n, Show b)
   => String
   -- ^ The name of the test.
   -> ProPredicate a b
   -- ^ The predicate to check.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
 dejafu = dejafuWithSettings defaultSettings
@@ -457,7 +455,7 @@ dejafu = dejafuWithSettings defaultSettings
 -- False
 --
 -- @since 1.0.0.0
-dejafuWay :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
+dejafuWay :: (MonadConc n, MonadIO n, Show b)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
@@ -466,7 +464,7 @@ dejafuWay :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
   -- ^ The name of the test.
   -> ProPredicate a b
   -- ^ The predicate to check.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
 dejafuWay way = dejafuWithSettings . fromWayAndMemType way
@@ -483,14 +481,14 @@ dejafuWay way = dejafuWithSettings . fromWayAndMemType way
 -- False
 --
 -- @since 1.2.0.0
-dejafuWithSettings :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
+dejafuWithSettings :: (MonadConc n, MonadIO n, Show b)
   => Settings n a
   -- ^ The SCT settings.
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
   -- ^ The predicate to check.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
 dejafuWithSettings settings name test =
@@ -506,7 +504,7 @@ dejafuWithSettings settings name test =
 -- False
 --
 -- @since 1.0.0.0
-dejafuDiscard :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
+dejafuDiscard :: (MonadConc n, MonadIO n, Show b)
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> Way
@@ -517,7 +515,7 @@ dejafuDiscard :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
   -- ^ The name of the test.
   -> ProPredicate a b
   -- ^ The predicate to check.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
 dejafuDiscard discard way =
@@ -536,10 +534,10 @@ dejafuDiscard discard way =
 -- False
 --
 -- @since 1.0.0.0
-dejafus :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
+dejafus :: (MonadConc n, MonadIO n, Show b)
   => [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
 dejafus = dejafusWithSettings defaultSettings
@@ -558,14 +556,14 @@ dejafus = dejafusWithSettings defaultSettings
 -- False
 --
 -- @since 1.0.0.0
-dejafusWay :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
+dejafusWay :: (MonadConc n, MonadIO n, Show b)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
 dejafusWay way = dejafusWithSettings . fromWayAndMemType way
@@ -583,12 +581,12 @@ dejafusWay way = dejafusWithSettings . fromWayAndMemType way
 -- False
 --
 -- @since 1.2.0.0
-dejafusWithSettings :: (MonadConc n, MonadIO n, MonadRef r n, Show b)
+dejafusWithSettings :: (MonadConc n, MonadIO n, Show b)
   => Settings n a
   -- ^ The SCT settings.
   -> [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
 dejafusWithSettings settings tests conc = do
@@ -659,10 +657,10 @@ instance Foldable Result where
 -- affect which failing traces are reported, when there is a failure.
 --
 -- @since 1.0.0.0
-runTest :: (MonadConc n, MonadRef r n)
+runTest :: MonadConc n
   => ProPredicate a b
   -- ^ The predicate to check
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test
   -> n (Result b)
 runTest = runTestWithSettings defaultSettings
@@ -675,14 +673,14 @@ runTest = runTestWithSettings defaultSettings
 -- affect which failing traces are reported, when there is a failure.
 --
 -- @since 1.0.0.0
-runTestWay :: (MonadConc n, MonadRef r n)
+runTestWay :: MonadConc n
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> ProPredicate a b
   -- ^ The predicate to check
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test
   -> n (Result b)
 runTestWay way = runTestWithSettings . fromWayAndMemType way
@@ -694,12 +692,12 @@ runTestWay way = runTestWithSettings . fromWayAndMemType way
 -- affect which failing traces are reported, when there is a failure.
 --
 -- @since 1.2.0.0
-runTestWithSettings :: (MonadConc n, MonadRef r n)
+runTestWithSettings :: MonadConc n
   => Settings n a
   -- ^ The SCT settings.
   -> ProPredicate a b
   -- ^ The predicate to check
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to test
   -> n (Result b)
 runTestWithSettings settings p conc =

--- a/dejafu/Test/DejaFu/Conc.hs
+++ b/dejafu/Test/DejaFu/Conc.hs
@@ -181,7 +181,7 @@ instance Monad n => C.MonadConc (ConcT r n) where
   readCRef   ref = toConc (AReadCRef    ref)
   readForCAS ref = toConc (AReadCRefCas ref)
 
-  peekTicket' _ = _ticketVal
+  peekTicket' _ = ticketVal
 
   writeCRef ref      a = toConc (\c -> AWriteCRef ref a (c ()))
   casCRef   ref tick a = toConc (ACasCRef ref tick a)

--- a/dejafu/Test/DejaFu/Conc.hs
+++ b/dejafu/Test/DejaFu/Conc.hs
@@ -78,7 +78,7 @@ import           Test.DejaFu.Utils
 import qualified Control.Monad.Fail                  as Fail
 #endif
 
--- | @since unreleased
+-- | @since 1.4.0.0
 newtype ConcT n a = C { unC :: ModelConc n a }
   deriving (Functor, Applicative, Monad)
 

--- a/dejafu/Test/DejaFu/Conc/Internal.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal.hs
@@ -58,7 +58,7 @@ data CResult n g a = CResult
 -- | A snapshot of the concurrency state immediately after 'dontCheck'
 -- finishes.
 --
--- @since unreleased
+-- @since 1.4.0.0
 data DCSnapshot n a = DCSnapshot
   { dcsContext :: Context n ()
   -- ^ The execution context.  The scheduler state is ignored when

--- a/dejafu/Test/DejaFu/Conc/Internal.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -9,14 +10,15 @@
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
--- Portability : MultiParamTypeClasses, RankNTypes, RecordWildCards, ScopedTypeVariables
+-- Portability : MultiParamTypeClasses, MultiWayIf, RankNTypes, RecordWildCards, ScopedTypeVariables
 --
 -- Concurrent monads with a fixed scheduler: internal types and
 -- functions. This module is NOT considered to form part of the public
 -- interface of this library.
 module Test.DejaFu.Conc.Internal where
 
-import           Control.Exception                   (MaskingState(..),
+import           Control.Exception                   (Exception,
+                                                      MaskingState(..),
                                                       toException)
 import           Control.Monad.Conc.Class            (MonadConc,
                                                       rtsSupportsBoundThreads)
@@ -275,6 +277,10 @@ data What n r g
 -- | Run a single thread one step, by dispatching on the type of
 -- 'Action'.
 --
+-- Each case looks very similar.  This is deliberate, so that the
+-- essential differences between actions are more apparent, and not
+-- hidden by accidental differences in how things are expressed.
+--
 -- Note: the returned snapshot action will definitely not do the right
 -- thing with relaxed memory.
 stepThread :: forall n r g. (MonadConc n, MonadRef r n)
@@ -293,304 +299,435 @@ stepThread :: forall n r g. (MonadConc n, MonadRef r n)
   -> Context n r g
   -- ^ The execution context.
   -> n (What n r g, Act, Threads n r -> n ())
-stepThread forSnapshot isFirst sched memtype tid action ctx = case action of
-    -- start a new thread, assigning it the next 'ThreadId'
-    AFork n a b -> pure $
-      let threads' = launch tid newtid a (cThreads ctx)
-          (idSource', newtid) = nextTId n (cIdSource ctx)
-      in (Succeeded ctx { cThreads = goto (b newtid) tid threads', cIdSource = idSource' }, Single (Fork newtid), noSnap)
+-- start a new thread, assigning it the next 'ThreadId'
+stepThread _ _ _ _ tid (AFork n a b) = \ctx@Context{..} -> pure $
+  let (idSource', newtid) = nextTId n cIdSource
+      threads' = launch tid newtid a cThreads
+  in ( Succeeded ctx { cThreads = goto (b newtid) tid threads', cIdSource = idSource' }
+     , Single (Fork newtid)
+     , const (pure ())
+     )
 
-    -- start a new bound thread, assigning it the next 'ThreadId'
-    AForkOS n a b -> do
-      let (idSource', newtid) = nextTId n (cIdSource ctx)
-      let threads' = launch tid newtid a (cThreads ctx)
-      threads'' <- makeBound newtid threads'
-      pure (Succeeded ctx { cThreads = goto (b newtid) tid threads'', cIdSource = idSource' }, Single (ForkOS newtid), noSnap)
+-- start a new bound thread, assigning it the next 'ThreadId'
+stepThread _ _ _ _ tid (AForkOS n a b) = \ctx@Context{..} -> do
+  let (idSource', newtid) = nextTId n cIdSource
+  let threads' = launch tid newtid a cThreads
+  threads'' <- makeBound newtid threads'
+  pure ( Succeeded ctx { cThreads = goto (b newtid) tid threads'', cIdSource = idSource' }
+       , Single (ForkOS newtid)
+       , const (pure ())
+       )
 
-    -- check if the current thread is bound
-    AIsBound c ->
-      let isBound = isJust . _bound $ elookup "stepThread.AIsBound" tid (cThreads ctx)
-      in simple (goto (c isBound) tid (cThreads ctx)) (IsCurrentThreadBound isBound) noSnap
+-- check if the current thread is bound
+stepThread _ _ _ _ tid (AIsBound c) = \ctx@Context{..} -> do
+  let isBound = isJust . _bound $ elookup "stepThread.AIsBound" tid cThreads
+  pure ( Succeeded ctx { cThreads = goto (c isBound) tid cThreads }
+       , Single (IsCurrentThreadBound isBound)
+       , const (pure ())
+       )
 
-    -- get the 'ThreadId' of the current thread
-    AMyTId c -> simple (goto (c tid) tid (cThreads ctx)) MyThreadId noSnap
+-- get the 'ThreadId' of the current thread
+stepThread _ _ _ _ tid (AMyTId c) = \ctx@Context{..} ->
+  pure ( Succeeded ctx { cThreads = goto (c tid) tid cThreads }
+       , Single MyThreadId
+       , const (pure ())
+       )
 
-    -- get the number of capabilities
-    AGetNumCapabilities c -> simple (goto (c (cCaps ctx)) tid (cThreads ctx)) (GetNumCapabilities $ cCaps ctx) noSnap
+-- get the number of capabilities
+stepThread _ _ _ _ tid (AGetNumCapabilities c) = \ctx@Context{..} ->
+  pure ( Succeeded ctx { cThreads = goto (c cCaps) tid cThreads }
+       , Single (GetNumCapabilities cCaps)
+       , const (pure ())
+       )
 
-    -- set the number of capabilities
-    ASetNumCapabilities i c -> pure
-      (Succeeded ctx { cThreads = goto c tid (cThreads ctx), cCaps = i }, Single (SetNumCapabilities i), noSnap)
+-- set the number of capabilities
+stepThread _ _ _ _ tid (ASetNumCapabilities i c) = \ctx@Context{..} ->
+  pure ( Succeeded ctx { cThreads = goto c tid cThreads, cCaps = i }
+       , Single (SetNumCapabilities i)
+       , const (pure ())
+       )
 
-    -- yield the current thread
-    AYield c -> simple (goto c tid (cThreads ctx)) Yield noSnap
+-- yield the current thread
+stepThread _ _ _ _ tid (AYield c) = \ctx@Context{..} ->
+  pure ( Succeeded ctx { cThreads = goto c tid cThreads }
+       , Single Yield
+       , const (pure ())
+       )
 
-    -- yield the current thread (delay is ignored)
-    ADelay n c -> simple (goto c tid (cThreads ctx)) (ThreadDelay n) noSnap
+-- yield the current thread (delay is ignored)
+stepThread _ _ _ _ tid (ADelay n c) = \ctx@Context{..} ->
+  pure ( Succeeded ctx { cThreads = goto c tid cThreads }
+       , Single (ThreadDelay n)
+       , const (pure ())
+       )
 
-    -- create a new @MVar@, using the next 'MVarId'.
-    ANewMVar n c -> do
-      let (idSource', newmvid) = nextMVId n (cIdSource ctx)
-      ref <- newRef Nothing
-      let mvar = ModelMVar newmvid ref
-      pure ( Succeeded ctx { cThreads = goto (c mvar) tid (cThreads ctx), cIdSource = idSource' }
-           , Single (NewMVar newmvid)
-           , const (writeRef ref Nothing)
+-- create a new @MVar@, using the next 'MVarId'.
+stepThread _ _ _ _ tid (ANewMVar n c) = \ctx@Context{..} -> do
+  let (idSource', newmvid) = nextMVId n cIdSource
+  ref <- newRef Nothing
+  let mvar = ModelMVar newmvid ref
+  pure ( Succeeded ctx { cThreads = goto (c mvar) tid cThreads, cIdSource = idSource' }
+       , Single (NewMVar newmvid)
+       , const (writeRef ref Nothing)
+       )
+
+-- put a value into a @MVar@, blocking the thread until it's empty.
+stepThread _ _ _ _ tid (APutMVar mvar@ModelMVar{..} a c) = synchronised $ \ctx@Context{..} -> do
+  (success, threads', woken, effect) <- putIntoMVar mvar a c tid cThreads
+  pure ( Succeeded ctx { cThreads = threads' }
+       , Single (if success then PutMVar mvarId woken else BlockedPutMVar mvarId)
+       , const effect
+       )
+
+-- try to put a value into a @MVar@, without blocking.
+stepThread _ _ _ _ tid (ATryPutMVar mvar@ModelMVar{..} a c) = synchronised $ \ctx@Context{..} -> do
+  (success, threads', woken, effect) <- tryPutIntoMVar mvar a c tid cThreads
+  pure ( Succeeded ctx { cThreads = threads' }
+       , Single (TryPutMVar mvarId success woken)
+       , const effect
+       )
+
+-- get the value from a @MVar@, without emptying, blocking the thread
+-- until it's full.
+stepThread _ _ _ _ tid (AReadMVar mvar@ModelMVar{..} c) = synchronised $ \ctx@Context{..} -> do
+  (success, threads', _, _) <- readFromMVar mvar c tid cThreads
+  pure ( Succeeded ctx { cThreads = threads' }
+       , Single (if success then ReadMVar mvarId else BlockedReadMVar mvarId)
+       , const (pure ())
+       )
+
+-- try to get the value from a @MVar@, without emptying, without
+-- blocking.
+stepThread _ _ _ _ tid (ATryReadMVar mvar@ModelMVar{..} c) = synchronised $ \ctx@Context{..} -> do
+  (success, threads', _, _) <- tryReadFromMVar mvar c tid cThreads
+  pure ( Succeeded ctx { cThreads = threads' }
+       , Single (TryReadMVar mvarId success)
+       , const (pure ())
+       )
+
+-- take the value from a @MVar@, blocking the thread until it's full.
+stepThread _ _ _ _ tid (ATakeMVar mvar@ModelMVar{..} c) = synchronised $ \ctx@Context{..} -> do
+  (success, threads', woken, effect) <- takeFromMVar mvar c tid cThreads
+  pure ( Succeeded ctx { cThreads = threads' }
+       , Single (if success then TakeMVar mvarId woken else BlockedTakeMVar mvarId)
+       , const effect
+       )
+
+-- try to take the value from a @MVar@, without blocking.
+stepThread _ _ _ _ tid (ATryTakeMVar mvar@ModelMVar{..} c) = synchronised $ \ctx@Context{..} -> do
+  (success, threads', woken, effect) <- tryTakeFromMVar mvar c tid cThreads
+  pure ( Succeeded ctx { cThreads = threads' }
+       , Single (TryTakeMVar mvarId success woken)
+       , const effect
+       )
+
+-- create a new @CRef@, using the next 'CRefId'.
+stepThread _ _ _ _  tid (ANewCRef n a c) = \ctx@Context{..} -> do
+  let (idSource', newcrid) = nextCRId n cIdSource
+  let val = (M.empty, 0, a)
+  ref <- newRef val
+  let cref = ModelCRef newcrid ref
+  pure ( Succeeded ctx { cThreads = goto (c cref) tid cThreads, cIdSource = idSource' }
+       , Single (NewCRef newcrid)
+       , const (writeRef ref val)
+       )
+
+-- read from a @CRef@.
+stepThread _ _ _ _  tid (AReadCRef cref@ModelCRef{..} c) = \ctx@Context{..} -> do
+  val <- readCRef cref tid
+  pure ( Succeeded ctx { cThreads = goto (c val) tid cThreads }
+       , Single (ReadCRef crefId)
+       , const (pure ())
+       )
+
+-- read from a @CRef@ for future compare-and-swap operations.
+stepThread _ _ _ _ tid (AReadCRefCas cref@ModelCRef{..} c) = \ctx@Context{..} -> do
+  tick <- readForTicket cref tid
+  pure ( Succeeded ctx { cThreads = goto (c tick) tid cThreads }
+       , Single (ReadCRefCas crefId)
+       , const (pure ())
+       )
+
+-- modify a @CRef@.
+stepThread _ _ _ _ tid (AModCRef cref@ModelCRef{..} f c) = synchronised $ \ctx@Context{..} -> do
+  (new, val) <- f <$> readCRef cref tid
+  effect <- writeImmediate cref new
+  pure ( Succeeded ctx { cThreads = goto (c val) tid cThreads }
+       , Single (ModCRef crefId)
+       , const effect
+       )
+
+-- modify a @CRef@ using a compare-and-swap.
+stepThread _ _ _ _ tid (AModCRefCas cref@ModelCRef{..} f c) = synchronised $ \ctx@Context{..} -> do
+  tick@(ModelTicket _ _ old) <- readForTicket cref tid
+  let (new, val) = f old
+  (_, _, effect) <- casCRef cref tid tick new
+  pure ( Succeeded ctx { cThreads = goto (c val) tid cThreads }
+       , Single (ModCRefCas crefId)
+       , const effect
+       )
+
+-- write to a @CRef@ without synchronising.
+stepThread _ _ _ memtype tid (AWriteCRef cref@ModelCRef{..} a c) = \ctx@Context{..} -> case memtype of
+  -- write immediately.
+  SequentialConsistency -> do
+    effect <- writeImmediate cref a
+    pure ( Succeeded ctx { cThreads = goto c tid cThreads }
+         , Single (WriteCRef crefId)
+         , const effect
+         )
+  -- add to buffer using thread id.
+  TotalStoreOrder -> do
+    wb' <- bufferWrite cWriteBuf (tid, Nothing) cref a
+    pure ( Succeeded ctx { cThreads = goto c tid cThreads, cWriteBuf = wb' }
+         , Single (WriteCRef crefId)
+         , const (pure ())
+         )
+  -- add to buffer using both thread id and cref id
+  PartialStoreOrder -> do
+    wb' <- bufferWrite cWriteBuf (tid, Just crefId) cref a
+    pure ( Succeeded ctx { cThreads = goto c tid cThreads, cWriteBuf = wb' }
+         , Single (WriteCRef crefId)
+         , const (pure ())
+         )
+
+-- perform a compare-and-swap on a @CRef@.
+stepThread _ _ _ _ tid (ACasCRef cref@ModelCRef{..} tick a c) = synchronised $ \ctx@Context{..} -> do
+  (suc, tick', effect) <- casCRef cref tid tick a
+  pure ( Succeeded ctx { cThreads = goto (c (suc, tick')) tid cThreads }
+       , Single (CasCRef crefId suc)
+       , const effect
+       )
+
+-- commit a @CRef@ write
+stepThread _ _ _ memtype _ (ACommit t c) = \ctx@Context{..} -> do
+  wb' <- case memtype of
+    -- shouldn't ever get here
+    SequentialConsistency ->
+      fatal "stepThread.ACommit" "Attempting to commit under SequentialConsistency"
+    -- commit using the thread id.
+    TotalStoreOrder ->
+      commitWrite cWriteBuf (t, Nothing)
+    -- commit using the cref id.
+    PartialStoreOrder ->
+      commitWrite cWriteBuf (t, Just c)
+  pure ( Succeeded ctx { cWriteBuf = wb' }
+       , Single (CommitCRef t c)
+       , const (pure ())
+       )
+
+-- run a STM transaction atomically.
+stepThread _ _ _ _ tid (AAtom stm c) = synchronised $ \ctx@Context{..} -> do
+  let transaction = runTransaction stm cIdSource
+  let effect = const (void transaction)
+  (res, idSource', trace) <- transaction
+  case res of
+    Success _ written val -> do
+      let (threads', woken) = wake (OnTVar written) cThreads
+      pure ( Succeeded ctx { cThreads = goto (c val) tid threads', cIdSource = idSource' }
+           , Single (STM trace woken)
+           , effect
            )
-
-    -- put a value into a @MVar@, blocking the thread until it's empty.
-    APutMVar mvar@ModelMVar{..} a c -> synchronised $ do
-      (success, threads', woken, effect) <- putIntoMVar mvar a c tid (cThreads ctx)
-      simple threads' (if success then PutMVar mvarId woken else BlockedPutMVar mvarId) (const effect)
-
-    -- try to put a value into a @MVar@, without blocking.
-    ATryPutMVar mvar@ModelMVar{..} a c -> synchronised $ do
-      (success, threads', woken, effect) <- tryPutIntoMVar mvar a c tid (cThreads ctx)
-      simple threads' (TryPutMVar mvarId success woken) (const effect)
-
-    -- get the value from a @MVar@, without emptying, blocking the
-    -- thread until it's full.
-    AReadMVar mvar@ModelMVar{..} c -> synchronised $ do
-      (success, threads', _, _) <- readFromMVar mvar c tid (cThreads ctx)
-      simple threads' (if success then ReadMVar mvarId else BlockedReadMVar mvarId) noSnap
-
-    -- try to get the value from a @MVar@, without emptying, without
-    -- blocking.
-    ATryReadMVar mvar@ModelMVar{..} c -> synchronised $ do
-      (success, threads', _, _) <- tryReadFromMVar mvar c tid (cThreads ctx)
-      simple threads' (TryReadMVar mvarId success) noSnap
-
-    -- take the value from a @MVar@, blocking the thread until it's
-    -- full.
-    ATakeMVar mvar@ModelMVar{..} c -> synchronised $ do
-      (success, threads', woken, effect) <- takeFromMVar mvar c tid (cThreads ctx)
-      simple threads' (if success then TakeMVar mvarId woken else BlockedTakeMVar mvarId) (const effect)
-
-    -- try to take the value from a @MVar@, without blocking.
-    ATryTakeMVar mvar@ModelMVar{..} c -> synchronised $ do
-      (success, threads', woken, effect) <- tryTakeFromMVar mvar c tid (cThreads ctx)
-      simple threads' (TryTakeMVar mvarId success woken) (const effect)
-
-    -- create a new @CRef@, using the next 'CRefId'.
-    ANewCRef n a c -> do
-      let (idSource', newcrid) = nextCRId n (cIdSource ctx)
-      let val = (M.empty, 0, a)
-      ref <- newRef val
-      let cref = ModelCRef newcrid ref
-      pure ( Succeeded ctx { cThreads = goto (c cref) tid (cThreads ctx), cIdSource = idSource' }
-           , Single (NewCRef newcrid)
-           , const (writeRef ref val)
+    Retry touched -> do
+      let threads' = block (OnTVar touched) tid cThreads
+      pure ( Succeeded ctx { cThreads = threads', cIdSource = idSource'}
+           , Single (BlockedSTM trace)
+           , effect
            )
+    Exception e -> do
+      let act = STM trace []
+      res' <- stepThrow act tid e ctx
+      pure $ case res' of
+        (Succeeded ctx', _, effect') -> (Succeeded ctx' { cIdSource = idSource' }, Single act, effect')
+        (Failed err, _, effect') -> (Failed err, Single act, effect')
+        (Snap _, _, _) -> fatal "stepThread.AAtom" "Unexpected snapshot while propagating STM exception"
 
-    -- read from a @CRef@.
-    AReadCRef cref@ModelCRef{..} c -> do
-      val <- readCRef cref tid
-      simple (goto (c val) tid (cThreads ctx)) (ReadCRef crefId) noSnap
+-- lift an action from the underlying monad into the @Conc@
+-- computation.
+stepThread _ _ _ _ tid (ALift na) = \ctx@Context{..} -> do
+  let effect threads = runLiftedAct tid threads na
+  a <- effect cThreads
+  pure (Succeeded ctx { cThreads = goto a tid cThreads }
+       , Single LiftIO
+       , void <$> effect
+       )
 
-    -- read from a @CRef@ for future compare-and-swap operations.
-    AReadCRefCas cref@ModelCRef{..} c -> do
-      tick <- readForTicket cref tid
-      simple (goto (c tick) tid (cThreads ctx)) (ReadCRefCas crefId) noSnap
+-- throw an exception, and propagate it to the appropriate handler.
+stepThread _ _ _ _ tid (AThrow e) = stepThrow Throw tid e
 
-    -- modify a @CRef@.
-    AModCRef cref@ModelCRef{..} f c -> synchronised $ do
-      (new, val) <- f <$> readCRef cref tid
-      effect <- writeImmediate cref new
-      simple (goto (c val) tid (cThreads ctx)) (ModCRef crefId) (const effect)
+-- throw an exception to the target thread, and propagate it to the
+-- appropriate handler.
+stepThread _ _ _ _ tid (AThrowTo t e c) = synchronised $ \ctx@Context{..} ->
+  let threads' = goto c tid cThreads
+      blocked  = block (OnMask t) tid cThreads
+  in case M.lookup t cThreads of
+       Just thread
+         | interruptible thread -> stepThrow (ThrowTo t) t e ctx { cThreads = threads' }
+         | otherwise -> pure
+           ( Succeeded ctx { cThreads = blocked }
+           , Single (BlockedThrowTo t)
+           , const (pure ())
+           )
+       Nothing -> pure
+         (Succeeded ctx { cThreads = threads' }
+         , Single (ThrowTo t)
+         , const (pure ())
+         )
 
-    -- modify a @CRef@ using a compare-and-swap.
-    AModCRefCas cref@ModelCRef{..} f c -> synchronised $ do
-      tick@(ModelTicket _ _ old) <- readForTicket cref tid
-      let (new, val) = f old
-      (_, _, effect) <- casCRef cref tid tick new
-      simple (goto (c val) tid (cThreads ctx)) (ModCRefCas crefId) (const effect)
+-- run a subcomputation in an exception-catching context.
+stepThread _ _ _ _ tid (ACatching h ma c) = \ctx@Context{..} -> pure $
+  let a     = runModelConc ma (APopCatching . c)
+      e exc = runModelConc (h exc) c
+  in ( Succeeded ctx { cThreads = goto a tid (catching e tid cThreads) }
+     , Single Catching
+     , const (pure ())
+     )
 
-    -- write to a @CRef@ without synchronising.
-    AWriteCRef cref@ModelCRef{..} a c -> case memtype of
-      -- write immediately.
-      SequentialConsistency -> do
-        effect <- writeImmediate cref a
-        simple (goto c tid (cThreads ctx)) (WriteCRef crefId) (const effect)
-      -- add to buffer using thread id.
-      TotalStoreOrder -> do
-        wb' <- bufferWrite (cWriteBuf ctx) (tid, Nothing) cref a
-        pure (Succeeded ctx { cThreads = goto c tid (cThreads ctx), cWriteBuf = wb' }, Single (WriteCRef crefId), noSnap)
-      -- add to buffer using both thread id and cref id
-      PartialStoreOrder -> do
-        wb' <- bufferWrite (cWriteBuf ctx) (tid, Just crefId) cref a
-        pure (Succeeded ctx { cThreads = goto c tid (cThreads ctx), cWriteBuf = wb' }, Single (WriteCRef crefId), noSnap)
+-- pop the top exception handler from the thread's stack.
+stepThread _ _ _ _ tid (APopCatching a) = \ctx@Context{..} ->
+  pure ( Succeeded ctx { cThreads = goto a tid (uncatching tid cThreads) }
+       , Single PopCatching
+       , const (pure ())
+       )
 
-    -- perform a compare-and-swap on a @CRef@.
-    ACasCRef cref@ModelCRef{..} tick a c -> synchronised $ do
-      (suc, tick', effect) <- casCRef cref tid tick a
-      simple (goto (c (suc, tick')) tid (cThreads ctx)) (CasCRef crefId suc) (const effect)
+-- execute a subcomputation with a new masking state, and give it a
+-- function to run a computation with the current masking state.
+stepThread _ _ _ _ tid (AMasking m ma c) = \ctx@Context{..} -> pure $
+  let resetMask typ ms = ModelConc $ \k -> AResetMask typ True ms $ k ()
+      umask mb = resetMask True m' >> mb >>= \b -> resetMask False m >> pure b
+      m' = _masking $ elookup "stepThread.AMasking" tid cThreads
+      a  = runModelConc (ma umask) (AResetMask False False m' . c)
+  in ( Succeeded ctx { cThreads = goto a tid (mask m tid cThreads) }
+     , Single (SetMasking False m)
+     , const (pure ())
+     )
 
-    -- commit a @CRef@ write
-    ACommit t c -> do
-      wb' <- case memtype of
-        -- shouldn't ever get here
-        SequentialConsistency ->
-          fatal "stepThread.ACommit" "Attempting to commit under SequentialConsistency"
-        -- commit using the thread id.
-        TotalStoreOrder -> commitWrite (cWriteBuf ctx) (t, Nothing)
-        -- commit using the cref id.
-        PartialStoreOrder -> commitWrite (cWriteBuf ctx) (t, Just c)
-      pure (Succeeded ctx { cWriteBuf = wb' }, Single (CommitCRef t c), noSnap)
+-- reset the masking thread of the state.
+stepThread _ _ _ _ tid (AResetMask b1 b2 m c) = \ctx@Context{..} ->
+  pure ( Succeeded ctx { cThreads = goto c tid (mask m tid cThreads) }
+       , Single ((if b1 then SetMasking else ResetMasking) b2 m)
+       , const (pure ())
+       )
 
-    -- run a STM transaction atomically.
-    AAtom stm c -> synchronised $ do
-      let transaction = runTransaction stm (cIdSource ctx)
-      let effect = const (void transaction)
-      (res, idSource', trace) <- transaction
-      case res of
-        Success _ written val ->
-          let (threads', woken) = wake (OnTVar written) (cThreads ctx)
-          in pure (Succeeded ctx { cThreads = goto (c val) tid threads', cIdSource = idSource' }, Single (STM trace woken), effect)
-        Retry touched ->
-          let threads' = block (OnTVar touched) tid (cThreads ctx)
-          in pure (Succeeded ctx { cThreads = threads', cIdSource = idSource'}, Single (BlockedSTM trace), effect)
-        Exception e -> do
-          let act = STM trace []
-          res' <- stepThrow tid (cThreads ctx) act e
-          pure $ case res' of
-            (Succeeded ctx', _, effect') -> (Succeeded ctx' { cIdSource = idSource' }, Single act, effect')
-            (Failed err, _, effect') -> (Failed err, Single act, effect')
-            (Snap _, _, _) -> fatal "stepThread.AAtom" "Unexpected snapshot while propagating STM exception"
+-- execute a 'return' or 'pure'.
+stepThread _ _ _ _ tid (AReturn c) = \ctx@Context{..} ->
+  pure ( Succeeded ctx { cThreads = goto c tid cThreads }
+       , Single Return
+       , const (pure ())
+       )
 
-    -- lift an action from the underlying monad into the @Conc@
-    -- computation.
-    ALift na -> do
-      let effect threads = runLiftedAct tid threads na
-      a <- effect (cThreads ctx)
-      simple (goto a tid (cThreads ctx)) LiftIO (void <$> effect)
+-- kill the current thread.
+stepThread _ _ _ _ tid (AStop na) = \ctx@Context{..} -> do
+  na
+  threads' <- kill tid cThreads
+  pure ( Succeeded ctx { cThreads = threads' }
+       , Single Stop
+       , const (pure ())
+       )
 
-    -- throw an exception, and propagate it to the appropriate
-    -- handler.
-    AThrow e -> stepThrow tid (cThreads ctx) Throw e
-
-    -- throw an exception to the target thread, and propagate it to
-    -- the appropriate handler.
-    AThrowTo t e c -> synchronised $
-      let threads' = goto c tid (cThreads ctx)
-          blocked  = block (OnMask t) tid (cThreads ctx)
-      in case M.lookup t (cThreads ctx) of
-           Just thread
-             | interruptible thread -> stepThrow t threads' (ThrowTo t) e
-             | otherwise -> simple blocked (BlockedThrowTo t) noSnap
-           Nothing -> simple threads' (ThrowTo t) noSnap
-
-    -- run a subcomputation in an exception-catching context.
-    ACatching h ma c ->
-      let a        = runModelConc ma (APopCatching . c)
-          e exc    = runModelConc (h exc) c
-          threads' = goto a tid (catching e tid (cThreads ctx))
-      in simple threads' Catching noSnap
-
-    -- pop the top exception handler from the thread's stack.
-    APopCatching a ->
-      let threads' = goto a tid (uncatching tid (cThreads ctx))
-      in simple threads' PopCatching noSnap
-
-    -- execute a subcomputation with a new masking state, and give it
-    -- a function to run a computation with the current masking state.
-    AMasking m ma c ->
-      let a        = runModelConc (ma umask) (AResetMask False False m' . c)
-          m'       = _masking $ elookup "stepThread.AMasking" tid (cThreads ctx)
-          umask mb = resetMask True m' >> mb >>= \b -> resetMask False m >> pure b
-          threads' = goto a tid (mask m tid (cThreads ctx))
-          resetMask typ ms = ModelConc $ \k -> AResetMask typ True ms $ k ()
-      in simple threads' (SetMasking False m) noSnap
-
-
-    -- reset the masking thread of the state.
-    AResetMask b1 b2 m c ->
-      let act      = (if b1 then SetMasking else ResetMasking) b2 m
-          threads' = goto c tid (mask m tid (cThreads ctx))
-      in simple threads' act noSnap
-
-    -- execute a 'return' or 'pure'.
-    AReturn c -> simple (goto c tid (cThreads ctx)) Return noSnap
-
-    -- kill the current thread.
-    AStop na -> do
-      na
-      threads' <- kill tid (cThreads ctx)
-      simple threads' Stop noSnap
-
-    -- run a subconcurrent computation.
-    ASub ma c
-      | forSnapshot -> pure (Failed IllegalSubconcurrency, Single Subconcurrency, noSnap)
-      | M.size (cThreads ctx) > 1 -> pure (Failed IllegalSubconcurrency, Single Subconcurrency, noSnap)
-      | otherwise -> do
-          res <- runConcurrency False sched memtype (cSchedState ctx) (cIdSource ctx) (cCaps ctx) ma
-          out <- efromJust "stepThread.ASub" <$> readRef (finalRef res)
-          pure (Succeeded ctx
+-- run a subconcurrent computation.
+stepThread forSnapshot _ sched memtype tid (ASub ma c) = \ctx ->
+  if | forSnapshot -> pure (Failed IllegalSubconcurrency, Single Subconcurrency, const (pure ()))
+     | M.size (cThreads ctx) > 1 -> pure (Failed IllegalSubconcurrency, Single Subconcurrency, const (pure ()))
+     | otherwise -> do
+         res <- runConcurrency False sched memtype (cSchedState ctx) (cIdSource ctx) (cCaps ctx) ma
+         out <- efromJust "stepThread.ASub" <$> readRef (finalRef res)
+         pure ( Succeeded ctx
                 { cThreads    = goto (AStopSub (c out)) tid (cThreads ctx)
                 , cIdSource   = cIdSource (finalContext res)
                 , cSchedState = cSchedState (finalContext res)
                 }
-               , SubC (finalTrace res) (finalDecision res)
-               , noSnap
+              , SubC (finalTrace res) (finalDecision res)
+              , const (pure ())
+              )
+
+-- after the end of a subconcurrent computation. does nothing, only
+-- exists so that: there is an entry in the trace for returning to
+-- normal computation; and every item in the trace corresponds to a
+-- scheduling point.
+stepThread _ _ _ _ tid (AStopSub c) = \ctx@Context{..} ->
+  pure ( Succeeded ctx { cThreads = goto c tid cThreads }
+       , Single StopSubconcurrency
+       , const (pure ())
+       )
+
+-- run an action atomically, with a non-preemptive length bounded
+-- round robin scheduler, under sequential consistency.
+stepThread forSnapshot isFirst _ _ tid (ADontCheck lb ma c) = \ctx ->
+  if | isFirst -> do
+         -- create a restricted context
+         threads' <- kill tid (cThreads ctx)
+         let dcCtx = ctx { cThreads = threads', cSchedState = lb }
+         res <- runConcurrency' forSnapshot dcSched SequentialConsistency dcCtx ma
+         out <- efromJust "stepThread.ADontCheck" <$> readRef (finalRef res)
+         case out of
+           Right a -> do
+             let threads'' = launch' Unmasked tid (const (c a)) (cThreads (finalContext res))
+             threads''' <- (if rtsSupportsBoundThreads then makeBound tid else pure) threads''
+             pure ( (if forSnapshot then Snap else Succeeded) (finalContext res)
+                    { cThreads = threads''', cSchedState = cSchedState ctx }
+                  , Single (DontCheck (toList (finalTrace res)))
+                  , fromMaybe (const (pure ())) (finalRestore res)
+                  )
+           Left f -> pure
+             ( Failed f
+             , Single (DontCheck (toList (finalTrace res)))
+             , const (pure ())
+             )
+     | otherwise -> pure
+       ( Failed IllegalDontCheck
+       , Single (DontCheck [])
+       , const (pure ())
+       )
+
+-- | Handle an exception being thrown from an @AAtom@, @AThrow@, or
+-- @AThrowTo@.
+stepThrow :: (MonadConc n, MonadRef r n, Exception e)
+  => ThreadAction
+  -- ^ Action to include in the trace.
+  -> ThreadId
+  -- ^ The thread receiving the exception.
+  -> e
+  -- ^ Exception to raise.
+  -> Context n r g
+  -- ^ The execution context.
+  -> n (What n r g, Act, Threads n r -> n ())
+stepThrow act tid e ctx@Context{..} = case propagate some tid cThreads of
+    Just ts' -> pure
+      ( Succeeded ctx { cThreads = ts' }
+      , Single act
+      , const (pure ())
+      )
+    Nothing
+      | tid == initialThread -> pure
+        ( Failed (UncaughtException some)
+        , Single act
+        , const (pure ())
+        )
+      | otherwise -> do
+          ts' <- kill tid cThreads
+          pure ( Succeeded ctx { cThreads = ts' }
+               , Single act
+               , const (pure ())
                )
-
-    -- after the end of a subconcurrent computation. does nothing,
-    -- only exists so that: there is an entry in the trace for
-    -- returning to normal computation; and every item in the trace
-    -- corresponds to a scheduling point.
-    AStopSub c -> simple (goto c tid (cThreads ctx)) StopSubconcurrency noSnap
-
-    -- run an action atomically, with a non-preemptive length bounded
-    -- round robin scheduler, under sequential consistency.
-    ADontCheck lb ma c
-      | isFirst -> do
-          -- create a restricted context
-          threads' <- kill tid (cThreads ctx)
-          let dcCtx = ctx { cThreads = threads', cSchedState = lb }
-          res <- runConcurrency' forSnapshot dcSched SequentialConsistency dcCtx ma
-          out <- efromJust "stepThread.ADontCheck" <$> readRef (finalRef res)
-          case out of
-            Right a -> do
-              let threads'' = launch' Unmasked tid (const (c a)) (cThreads (finalContext res))
-              threads''' <- (if rtsSupportsBoundThreads then makeBound tid else pure) threads''
-              pure ( (if forSnapshot then Snap else Succeeded) (finalContext res) { cThreads = threads''', cSchedState = cSchedState ctx }
-                   , Single (DontCheck (toList (finalTrace res)))
-                   , fromMaybe noSnap (finalRestore res)
-                   )
-            Left f ->
-              pure (Failed f, Single (DontCheck (toList (finalTrace res))), noSnap)
-      | otherwise -> pure (Failed IllegalDontCheck, Single (DontCheck []), noSnap)
   where
+    some = toException e
 
-    -- this is not inline in the long @case@ above as it's needed by
-    -- @AAtom@, @AThrow@, and @AThrowTo@.
-    stepThrow t ts act e =
-      let some = toException e
-      in case propagate some t ts of
-           Just ts' -> simple ts' act noSnap
-           Nothing
-             | t == initialThread -> pure (Failed (UncaughtException some), Single act, noSnap)
-             | otherwise -> do
-                 ts' <- kill t ts
-                 simple ts' act noSnap
+-- | Helper for actions impose a write barrier.
+synchronised :: (Monad n, MonadRef r n)
+  => (Context n r g -> n (What n r g, Act, Threads n r -> n ()))
+  -- ^ Action to run after the write barrier.
+  -> Context n r g
+  -- ^ The original execution context.
+  -> n (What n r g, Act, Threads n r -> n ())
+synchronised ma ctx@Context{..} = do
+  writeBarrier cWriteBuf
+  ma ctx { cWriteBuf = emptyBuffer }
 
-    -- helper for actions which only change the threads.
-    simple threads' act effect = pure (Succeeded ctx { cThreads = threads' }, Single act, effect)
-
-    -- helper for actions impose a write barrier.
-    synchronised ma = do
-      writeBarrier (cWriteBuf ctx)
-      res <- ma
-
-      pure $ case res of
-        (Succeeded ctx', act, effect) -> (Succeeded ctx' { cWriteBuf = emptyBuffer }, act, effect)
-        _ -> res
-
-    -- scheduler for @ADontCheck@
-    dcSched = Scheduler go where
-      go _ _ (Just 0) = (Nothing, Just 0)
-      go prior threads s =
-        let (t, _) = scheduleThread roundRobinSchedNP prior threads ()
-        in (t, fmap (\lb -> lb - 1) s)
-
-    -- no snapshot
-    noSnap _ = pure ()
+-- | scheduler for @ADontCheck@
+dcSched :: Scheduler (Maybe Int)
+dcSched = Scheduler go where
+  go _ _ (Just 0) = (Nothing, Just 0)
+  go prior threads s =
+    let (t, _) = scheduleThread roundRobinSchedNP prior threads ()
+    in (t, fmap (\lb -> lb - 1) s)

--- a/dejafu/Test/DejaFu/Conc/Internal/Common.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Common.hs
@@ -61,25 +61,25 @@ instance Fail.MonadFail (ModelConc n r) where
 -- | An @MVar@ is modelled as a unique ID and a reference holding a
 -- @Maybe@ value.
 data ModelMVar r a = ModelMVar
-  { _mvarId  :: MVarId
-  , _mvarRef :: r (Maybe a)
+  { mvarId  :: MVarId
+  , mvarRef :: r (Maybe a)
   }
 
 -- | A @CRef@ is modelled as a unique ID and a reference holding
 -- thread-local values, the number of commits, and the most recent
 -- committed value.
 data ModelCRef r a = ModelCRef
-  { _crefId  :: CRefId
-  , _crefRef :: r (Map ThreadId a, Integer, a)
+  { crefId  :: CRefId
+  , crefRef :: r (Map ThreadId a, Integer, a)
   }
 
 -- | A @Ticket@ is modelled as the ID of the @ModelCRef@ it came from,
 -- the commits to the @ModelCRef@ at the time it was produced, and the
 -- value observed.
 data ModelTicket a = ModelTicket
-  { _ticketCRef   :: CRefId
-  , _ticketWrites :: Integer
-  , _ticketVal    :: a
+  { ticketCRef   :: CRefId
+  , ticketWrites :: Integer
+  , ticketVal    :: a
   }
 
 --------------------------------------------------------------------------------

--- a/dejafu/Test/DejaFu/Conc/Internal/Common.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Common.hs
@@ -17,7 +17,7 @@ module Test.DejaFu.Conc.Internal.Common where
 
 import           Control.Exception             (Exception, MaskingState(..))
 import           Data.Map.Strict               (Map)
-import           Test.DejaFu.Conc.Internal.STM (S)
+import           Test.DejaFu.Conc.Internal.STM (ModelSTM)
 import           Test.DejaFu.Types
 
 #if MIN_VERSION_base(4,9,0)
@@ -25,7 +25,7 @@ import qualified Control.Monad.Fail            as Fail
 #endif
 
 --------------------------------------------------------------------------------
--- * The @Conc@ Monad
+-- * The @ModelConc@ Monad
 
 -- | The underlying monad is based on continuations over 'Action's.
 --
@@ -35,72 +35,52 @@ import qualified Control.Monad.Fail            as Fail
 -- current expression of threads and exception handlers very difficult
 -- (perhaps even not possible without significant reworking), so I
 -- abandoned the attempt.
-newtype M n r a = M { runM :: (a -> Action n r) -> Action n r }
+newtype ModelConc n r a = ModelConc { runModelConc :: (a -> Action n r) -> Action n r }
 
-instance Functor (M n r) where
-    fmap f m = M $ \ c -> runM m (c . f)
+instance Functor (ModelConc n r) where
+    fmap f m = ModelConc $ \ c -> runModelConc m (c . f)
 
-instance Applicative (M n r) where
+instance Applicative (ModelConc n r) where
     -- without the @AReturn@, a thread could lock up testing by
     -- entering an infinite loop (eg: @forever (return ())@)
-    pure x  = M $ \c -> AReturn $ c x
-    f <*> v = M $ \c -> runM f (\g -> runM v (c . g))
+    pure x  = ModelConc $ \c -> AReturn $ c x
+    f <*> v = ModelConc $ \c -> runModelConc f (\g -> runModelConc v (c . g))
 
-instance Monad (M n r) where
+instance Monad (ModelConc n r) where
     return  = pure
-    m >>= k = M $ \c -> runM m (\x -> runM (k x) c)
+    m >>= k = ModelConc $ \c -> runModelConc m (\x -> runModelConc (k x) c)
 
 #if MIN_VERSION_base(4,9,0)
     fail = Fail.fail
 
 -- | @since 0.7.1.2
-instance Fail.MonadFail (M n r) where
+instance Fail.MonadFail (ModelConc n r) where
 #endif
-    fail e = cont (\_ -> AThrow (MonadFailException e))
+    fail e = ModelConc $ \_ -> AThrow (MonadFailException e)
 
--- | The concurrent variable type used with the 'Conc' monad. One
--- notable difference between these and 'MVar's is that 'MVar's are
--- single-wakeup, and wake up in a FIFO order. Writing to a @MVar@
--- wakes up all threads blocked on reading it, and it is up to the
--- scheduler which one runs next. Taking from a @MVar@ behaves
--- analogously.
-data MVar r a = MVar
-  { _cvarId   :: MVarId
-  , _cvarVal  :: r (Maybe a)
+-- | An @MVar@ is modelled as a unique ID and a reference holding a
+-- @Maybe@ value.
+data ModelMVar r a = ModelMVar
+  { _mvarId  :: MVarId
+  , _mvarRef :: r (Maybe a)
   }
 
--- | The mutable non-blocking reference type. These are like 'IORef's.
---
--- @CRef@s are represented as a unique numeric identifier and a
--- reference containing (a) any thread-local non-synchronised writes
--- (so each thread sees its latest write), (b) a commit count (used in
--- compare-and-swaps), and (c) the current value visible to all
--- threads.
-data CRef r a = CRef
-  { _crefId   :: CRefId
-  , _crefVal  :: r (Map ThreadId a, Integer, a)
+-- | A @CRef@ is modelled as a unique ID and a reference holding
+-- thread-local values, the number of commits, and the most recent
+-- committed value.
+data ModelCRef r a = ModelCRef
+  { _crefId  :: CRefId
+  , _crefRef :: r (Map ThreadId a, Integer, a)
   }
 
--- | The compare-and-swap proof type.
---
--- @Ticket@s are represented as just a wrapper around the identifier
--- of the 'CRef' it came from, the commit count at the time it was
--- produced, and an @a@ value. This doesn't work in the source package
--- (atomic-primops) because of the need to use pointer equality. Here
--- we can just pack extra information into 'CRef' to avoid that need.
-data Ticket a = Ticket
+-- | A @Ticket@ is modelled as the ID of the @ModelCRef@ it came from,
+-- the commits to the @ModelCRef@ at the time it was produced, and the
+-- value observed.
+data ModelTicket a = ModelTicket
   { _ticketCRef   :: CRefId
   , _ticketWrites :: Integer
   , _ticketVal    :: a
   }
-
--- | Construct a continuation-passing operation from a function.
-cont :: ((a -> Action n r) -> Action n r) -> M n r a
-cont = M
-
--- | Run a CPS computation with the given final computation.
-runCont :: M n r a -> (a -> Action n r) -> Action n r
-runCont = runM
 
 --------------------------------------------------------------------------------
 -- * Primitive Actions
@@ -110,38 +90,38 @@ runCont = runM
 -- primitives of the concurrency. 'spawn' is absent as it is
 -- implemented in terms of 'newEmptyMVar', 'fork', and 'putMVar'.
 data Action n r =
-    AFork   String ((forall b. M n r b -> M n r b) -> Action n r) (ThreadId -> Action n r)
-  | AForkOS String ((forall b. M n r b -> M n r b) -> Action n r) (ThreadId -> Action n r)
+    AFork   String ((forall b. ModelConc n r b -> ModelConc n r b) -> Action n r) (ThreadId -> Action n r)
+  | AForkOS String ((forall b. ModelConc n r b -> ModelConc n r b) -> Action n r) (ThreadId -> Action n r)
   | AIsBound (Bool -> Action n r)
   | AMyTId (ThreadId -> Action n r)
 
   | AGetNumCapabilities (Int -> Action n r)
   | ASetNumCapabilities Int (Action n r)
 
-  | forall a. ANewMVar String (MVar r a -> Action n r)
-  | forall a. APutMVar     (MVar r a) a (Action n r)
-  | forall a. ATryPutMVar  (MVar r a) a (Bool -> Action n r)
-  | forall a. AReadMVar    (MVar r a) (a -> Action n r)
-  | forall a. ATryReadMVar (MVar r a) (Maybe a -> Action n r)
-  | forall a. ATakeMVar    (MVar r a) (a -> Action n r)
-  | forall a. ATryTakeMVar (MVar r a) (Maybe a -> Action n r)
+  | forall a. ANewMVar String (ModelMVar r a -> Action n r)
+  | forall a. APutMVar     (ModelMVar r a) a (Action n r)
+  | forall a. ATryPutMVar  (ModelMVar r a) a (Bool -> Action n r)
+  | forall a. AReadMVar    (ModelMVar r a) (a -> Action n r)
+  | forall a. ATryReadMVar (ModelMVar r a) (Maybe a -> Action n r)
+  | forall a. ATakeMVar    (ModelMVar r a) (a -> Action n r)
+  | forall a. ATryTakeMVar (ModelMVar r a) (Maybe a -> Action n r)
 
-  | forall a.   ANewCRef String a (CRef r a -> Action n r)
-  | forall a.   AReadCRef    (CRef r a) (a -> Action n r)
-  | forall a.   AReadCRefCas (CRef r a) (Ticket a -> Action n r)
-  | forall a b. AModCRef     (CRef r a) (a -> (a, b)) (b -> Action n r)
-  | forall a b. AModCRefCas  (CRef r a) (a -> (a, b)) (b -> Action n r)
-  | forall a.   AWriteCRef   (CRef r a) a (Action n r)
-  | forall a.   ACasCRef     (CRef r a) (Ticket a) a ((Bool, Ticket a) -> Action n r)
+  | forall a.   ANewCRef String a (ModelCRef r a -> Action n r)
+  | forall a.   AReadCRef    (ModelCRef r a) (a -> Action n r)
+  | forall a.   AReadCRefCas (ModelCRef r a) (ModelTicket a -> Action n r)
+  | forall a b. AModCRef     (ModelCRef r a) (a -> (a, b)) (b -> Action n r)
+  | forall a b. AModCRefCas  (ModelCRef r a) (a -> (a, b)) (b -> Action n r)
+  | forall a.   AWriteCRef   (ModelCRef r a) a (Action n r)
+  | forall a.   ACasCRef     (ModelCRef r a) (ModelTicket a) a ((Bool, ModelTicket a) -> Action n r)
 
   | forall e.   Exception e => AThrow e
   | forall e.   Exception e => AThrowTo ThreadId e (Action n r)
-  | forall a e. Exception e => ACatching (e -> M n r a) (M n r a) (a -> Action n r)
+  | forall a e. Exception e => ACatching (e -> ModelConc n r a) (ModelConc n r a) (a -> Action n r)
   | APopCatching (Action n r)
-  | forall a. AMasking MaskingState ((forall b. M n r b -> M n r b) -> M n r a) (a -> Action n r)
+  | forall a. AMasking MaskingState ((forall b. ModelConc n r b -> ModelConc n r b) -> ModelConc n r a) (a -> Action n r)
   | AResetMask Bool Bool MaskingState (Action n r)
 
-  | forall a. AAtom (S n r a) (a -> Action n r)
+  | forall a. AAtom (ModelSTM n r a) (a -> Action n r)
   | ALift (n (Action n r))
   | AYield  (Action n r)
   | ADelay Int (Action n r)
@@ -149,9 +129,9 @@ data Action n r =
   | ACommit ThreadId CRefId
   | AStop (n ())
 
-  | forall a. ASub (M n r a) (Either Failure a -> Action n r)
+  | forall a. ASub (ModelConc n r a) (Either Failure a -> Action n r)
   | AStopSub (Action n r)
-  | forall a. ADontCheck (Maybe Int) (M n r a) (a -> Action n r)
+  | forall a. ADontCheck (Maybe Int) (ModelConc n r a) (a -> Action n r)
 
 --------------------------------------------------------------------------------
 -- * Scheduling & Traces
@@ -165,19 +145,19 @@ lookahead (AMyTId _) = WillMyThreadId
 lookahead (AGetNumCapabilities _) = WillGetNumCapabilities
 lookahead (ASetNumCapabilities i _) = WillSetNumCapabilities i
 lookahead (ANewMVar _ _) = WillNewMVar
-lookahead (APutMVar (MVar c _) _ _) = WillPutMVar c
-lookahead (ATryPutMVar (MVar c _) _ _) = WillTryPutMVar c
-lookahead (AReadMVar (MVar c _) _) = WillReadMVar c
-lookahead (ATryReadMVar (MVar c _) _) = WillTryReadMVar c
-lookahead (ATakeMVar (MVar c _) _) = WillTakeMVar c
-lookahead (ATryTakeMVar (MVar c _) _) = WillTryTakeMVar c
+lookahead (APutMVar (ModelMVar m _) _ _) = WillPutMVar m
+lookahead (ATryPutMVar (ModelMVar m _) _ _) = WillTryPutMVar m
+lookahead (AReadMVar (ModelMVar m _) _) = WillReadMVar m
+lookahead (ATryReadMVar (ModelMVar m _) _) = WillTryReadMVar m
+lookahead (ATakeMVar (ModelMVar m _) _) = WillTakeMVar m
+lookahead (ATryTakeMVar (ModelMVar m _) _) = WillTryTakeMVar m
 lookahead (ANewCRef _ _ _) = WillNewCRef
-lookahead (AReadCRef (CRef r _) _) = WillReadCRef r
-lookahead (AReadCRefCas (CRef r _) _) = WillReadCRefCas r
-lookahead (AModCRef (CRef r _) _ _) = WillModCRef r
-lookahead (AModCRefCas (CRef r _) _ _) = WillModCRefCas r
-lookahead (AWriteCRef (CRef r _) _ _) = WillWriteCRef r
-lookahead (ACasCRef (CRef r _) _ _ _) = WillCasCRef r
+lookahead (AReadCRef (ModelCRef r _) _) = WillReadCRef r
+lookahead (AReadCRefCas (ModelCRef r _) _) = WillReadCRefCas r
+lookahead (AModCRef (ModelCRef r _) _ _) = WillModCRef r
+lookahead (AModCRefCas (ModelCRef r _) _ _) = WillModCRefCas r
+lookahead (AWriteCRef (ModelCRef r _) _ _) = WillWriteCRef r
+lookahead (ACasCRef (ModelCRef r _) _ _ _) = WillCasCRef r
 lookahead (ACommit t c) = WillCommitCRef t c
 lookahead (AAtom _ _) = WillSTM
 lookahead (AThrow _) = WillThrow

--- a/dejafu/Test/DejaFu/Conc/Internal/STM.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/STM.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- Must come after TypeFamilies
@@ -12,7 +13,7 @@
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
--- Portability : CPP, ExistentialQuantification, MultiParamTypeClasses, NoMonoLocalBinds, TypeFamilies
+-- Portability : CPP, ExistentialQuantification, MultiParamTypeClasses, NoMonoLocalBinds, RecordWildCards, TypeFamilies
 --
 -- 'MonadSTM' testing implementation, internal types and definitions.
 -- This module is NOT considered to form part of the public interface
@@ -204,14 +205,14 @@ stepTrans act idsource = case act of
         Just exc' -> transaction (TCatch trace . Just) (h exc') c
         Nothing   -> pure (SThrow exc, nothing, idsource, [], [], TCatch trace Nothing))
 
-    stepRead (ModelTVar tvid ref) c = do
-      val <- readRef ref
-      pure (c val, nothing, idsource, [tvid], [], TRead tvid)
+    stepRead ModelTVar{..} c = do
+      val <- readRef tvarRef
+      pure (c val, nothing, idsource, [tvarId], [], TRead tvarId)
 
-    stepWrite (ModelTVar tvid ref) a c = do
-      old <- readRef ref
-      writeRef ref a
-      pure (c, writeRef ref old, idsource, [], [tvid], TWrite tvid)
+    stepWrite ModelTVar{..} a c = do
+      old <- readRef tvarRef
+      writeRef tvarRef a
+      pure (c, writeRef tvarRef old, idsource, [], [tvarId], TWrite tvarId)
 
     stepNew n a c = do
       let (idsource', tvid) = nextTVId n idsource

--- a/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
@@ -13,10 +13,10 @@
 -- form part of the public interface of this library.
 module Test.DejaFu.Conc.Internal.Threading where
 
-import qualified Control.Concurrent.Classy        as C
 import           Control.Exception                (Exception, MaskingState(..),
                                                    SomeException, fromException)
 import           Control.Monad                    (forever)
+import qualified Control.Monad.Conc.Class         as C
 import           Data.List                        (intersect)
 import           Data.Map.Strict                  (Map)
 import qualified Data.Map.Strict                  as M
@@ -30,34 +30,34 @@ import           Test.DejaFu.Types
 -- * Threads
 
 -- | Threads are stored in a map index by 'ThreadId'.
-type Threads n r = Map ThreadId (Thread n r)
+type Threads n = Map ThreadId (Thread n)
 
 -- | All the state of a thread.
-data Thread n r = Thread
-  { _continuation :: Action n r
+data Thread n = Thread
+  { _continuation :: Action n
   -- ^ The next action to execute.
   , _blocking     :: Maybe BlockedOn
   -- ^ The state of any blocks.
-  , _handlers     :: [Handler n r]
+  , _handlers     :: [Handler n]
   -- ^ Stack of exception handlers
   , _masking      :: MaskingState
   -- ^ The exception masking state.
-  , _bound        :: Maybe (BoundThread n r)
+  , _bound        :: Maybe (BoundThread n)
   -- ^ State for the associated bound thread, if it exists.
   }
 
 -- | The state of a bound thread.
-data BoundThread n r = BoundThread
-  { _runboundIO :: C.MVar n (n (Action n r))
+data BoundThread n = BoundThread
+  { _runboundIO :: C.MVar n (n (Action n))
   -- ^ Run an @IO@ action in the bound thread by writing to this.
-  , _getboundIO :: C.MVar n (Action n r)
+  , _getboundIO :: C.MVar n (Action n)
   -- ^ Get the result of the above by reading from this.
   , _boundTId   :: C.ThreadId n
   -- ^ Thread ID
   }
 
 -- | Construct a thread with just one action
-mkthread :: Action n r -> Thread n r
+mkthread :: Action n -> Thread n
 mkthread c = Thread c Nothing [] Unmasked Nothing
 
 --------------------------------------------------------------------------------
@@ -68,7 +68,7 @@ mkthread c = Thread c Nothing [] Unmasked Nothing
 data BlockedOn = OnMVarFull MVarId | OnMVarEmpty MVarId | OnTVar [TVarId] | OnMask ThreadId deriving Eq
 
 -- | Determine if a thread is blocked in a certain way.
-(~=) :: Thread n r -> BlockedOn -> Bool
+(~=) :: Thread n -> BlockedOn -> Bool
 thread ~= theblock = case (_blocking thread, theblock) of
   (Just (OnMVarFull  _), OnMVarFull  _) -> True
   (Just (OnMVarEmpty _), OnMVarEmpty _) -> True
@@ -80,11 +80,11 @@ thread ~= theblock = case (_blocking thread, theblock) of
 -- * Exceptions
 
 -- | An exception handler.
-data Handler n r = forall e. Exception e => Handler (e -> MaskingState -> Action n r)
+data Handler n = forall e. Exception e => Handler (e -> MaskingState -> Action n)
 
 -- | Propagate an exception upwards, finding the closest handler
 -- which can deal with it.
-propagate :: SomeException -> ThreadId -> Threads n r -> Maybe (Threads n r)
+propagate :: SomeException -> ThreadId -> Threads n -> Maybe (Threads n)
 propagate e tid threads = raise <$> propagate' handlers where
   handlers = _handlers (elookup "propagate" tid threads)
 
@@ -94,23 +94,25 @@ propagate e tid threads = raise <$> propagate' handlers where
   propagate' (Handler h:hs) = maybe (propagate' hs) (\act -> Just (act, hs)) $ h <$> fromException e
 
 -- | Check if a thread can be interrupted by an exception.
-interruptible :: Thread n r -> Bool
-interruptible thread = _masking thread == Unmasked || (_masking thread == MaskedInterruptible && isJust (_blocking thread))
+interruptible :: Thread n -> Bool
+interruptible thread =
+  _masking thread == Unmasked ||
+  (_masking thread == MaskedInterruptible && isJust (_blocking thread))
 
 -- | Register a new exception handler.
-catching :: Exception e => (e -> Action n r) -> ThreadId -> Threads n r -> Threads n r
+catching :: Exception e => (e -> Action n) -> ThreadId -> Threads n -> Threads n
 catching h = eadjust "catching" $ \thread ->
   let ms0 = _masking thread
       h'  = Handler $ \e ms -> (if ms /= ms0 then AResetMask False False ms0 else id) (h e)
   in thread { _handlers = h' : _handlers thread }
 
 -- | Remove the most recent exception handler.
-uncatching :: ThreadId -> Threads n r -> Threads n r
+uncatching :: ThreadId -> Threads n -> Threads n
 uncatching = eadjust "uncatching" $ \thread ->
   thread { _handlers = etail "uncatching" (_handlers thread) }
 
 -- | Raise an exception in a thread.
-except :: (MaskingState -> Action n r) -> [Handler n r] -> ThreadId -> Threads n r -> Threads n r
+except :: (MaskingState -> Action n) -> [Handler n] -> ThreadId -> Threads n -> Threads n
 except actf hs = eadjust "except" $ \thread -> thread
   { _continuation = actf (_masking thread)
   , _handlers = hs
@@ -118,24 +120,24 @@ except actf hs = eadjust "except" $ \thread -> thread
   }
 
 -- | Set the masking state of a thread.
-mask :: MaskingState -> ThreadId -> Threads n r -> Threads n r
+mask :: MaskingState -> ThreadId -> Threads n -> Threads n
 mask ms = eadjust "mask" $ \thread -> thread { _masking = ms }
 
 --------------------------------------------------------------------------------
 -- * Manipulating threads
 
 -- | Replace the @Action@ of a thread.
-goto :: Action n r -> ThreadId -> Threads n r -> Threads n r
+goto :: Action n -> ThreadId -> Threads n -> Threads n
 goto a = eadjust "goto" $ \thread -> thread { _continuation = a }
 
 -- | Start a thread with the given ID, inheriting the masking state
 -- from the parent thread. This ID must not already be in use!
-launch :: ThreadId -> ThreadId -> ((forall b. ModelConc n r b -> ModelConc n r b) -> Action n r) -> Threads n r -> Threads n r
+launch :: ThreadId -> ThreadId -> ((forall b. ModelConc n b -> ModelConc n b) -> Action n) -> Threads n -> Threads n
 launch parent tid a threads = launch' ms tid a threads where
   ms = _masking (elookup "launch" parent threads)
 
 -- | Start a thread with the given ID and masking state. This must not already be in use!
-launch' :: MaskingState -> ThreadId -> ((forall b. ModelConc n r b -> ModelConc n r b) -> Action n r) -> Threads n r -> Threads n r
+launch' :: MaskingState -> ThreadId -> ((forall b. ModelConc n b -> ModelConc n b) -> Action n) -> Threads n -> Threads n
 launch' ms tid a = einsert "launch'" tid thread where
   thread = Thread (a umask) Nothing [] ms Nothing
 
@@ -143,13 +145,13 @@ launch' ms tid a = einsert "launch'" tid thread where
   resetMask typ m = ModelConc $ \k -> AResetMask typ True m $ k ()
 
 -- | Block a thread.
-block :: BlockedOn -> ThreadId -> Threads n r -> Threads n r
+block :: BlockedOn -> ThreadId -> Threads n -> Threads n
 block blockedOn = eadjust "block" $ \thread -> thread { _blocking = Just blockedOn }
 
 -- | Unblock all threads waiting on the appropriate block. For 'TVar'
 -- blocks, this will wake all threads waiting on at least one of the
 -- given 'TVar's.
-wake :: BlockedOn -> Threads n r -> (Threads n r, [ThreadId])
+wake :: BlockedOn -> Threads n -> (Threads n, [ThreadId])
 wake blockedOn threads = (unblock <$> threads, M.keys $ M.filter isBlocked threads) where
   unblock thread
     | isBlocked thread = thread { _blocking = Nothing }
@@ -163,7 +165,7 @@ wake blockedOn threads = (unblock <$> threads, M.keys $ M.filter isBlocked threa
 -- ** Bound threads
 
 -- | Turn a thread into a bound thread.
-makeBound :: C.MonadConc n => ThreadId -> Threads n r -> n (Threads n r)
+makeBound :: C.MonadConc n => ThreadId -> Threads n -> n (Threads n)
 makeBound tid threads = do
     runboundIO <- C.newEmptyMVar
     getboundIO <- C.newEmptyMVar
@@ -178,7 +180,7 @@ makeBound tid threads = do
 -- | Kill a thread and remove it from the thread map.
 --
 -- If the thread is bound, the worker thread is cleaned up.
-kill :: C.MonadConc n => ThreadId -> Threads n r -> n (Threads n r)
+kill :: C.MonadConc n => ThreadId -> Threads n -> n (Threads n)
 kill tid threads = do
   let thread = elookup "kill" tid threads
   maybe (pure ()) (C.killThread . _boundTId) (_bound thread)
@@ -187,7 +189,7 @@ kill tid threads = do
 -- | Run an action.
 --
 -- If the thread is bound, the action is run in the worker thread.
-runLiftedAct :: C.MonadConc n => ThreadId -> Threads n r -> n (Action n r) -> n (Action n r)
+runLiftedAct :: C.MonadConc n => ThreadId -> Threads n -> n (Action n) -> n (Action n)
 runLiftedAct tid threads ma = case _bound =<< M.lookup tid threads of
   Just bt -> do
     C.putMVar (_runboundIO bt) ma

--- a/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
@@ -130,17 +130,17 @@ goto a = eadjust "goto" $ \thread -> thread { _continuation = a }
 
 -- | Start a thread with the given ID, inheriting the masking state
 -- from the parent thread. This ID must not already be in use!
-launch :: ThreadId -> ThreadId -> ((forall b. M n r b -> M n r b) -> Action n r) -> Threads n r -> Threads n r
+launch :: ThreadId -> ThreadId -> ((forall b. ModelConc n r b -> ModelConc n r b) -> Action n r) -> Threads n r -> Threads n r
 launch parent tid a threads = launch' ms tid a threads where
   ms = _masking (elookup "launch" parent threads)
 
 -- | Start a thread with the given ID and masking state. This must not already be in use!
-launch' :: MaskingState -> ThreadId -> ((forall b. M n r b -> M n r b) -> Action n r) -> Threads n r -> Threads n r
+launch' :: MaskingState -> ThreadId -> ((forall b. ModelConc n r b -> ModelConc n r b) -> Action n r) -> Threads n r -> Threads n r
 launch' ms tid a = einsert "launch'" tid thread where
   thread = Thread (a umask) Nothing [] ms Nothing
 
   umask mb = resetMask True Unmasked >> mb >>= \b -> resetMask False ms >> pure b
-  resetMask typ m = cont $ \k -> AResetMask typ True m $ k ()
+  resetMask typ m = ModelConc $ \k -> AResetMask typ True m $ k ()
 
 -- | Block a thread.
 block :: BlockedOn -> ThreadId -> Threads n r -> Threads n r

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -155,50 +155,49 @@ tvarsRead act = S.fromList $ case act of
     tvarsOf' _ = []
 
 -- | Convert a 'ThreadAction' into a 'Lookahead': \"rewind\" what has
--- happened. 'Killed' has no 'Lookahead' counterpart.
-rewind :: ThreadAction -> Maybe Lookahead
-rewind (Fork _) = Just WillFork
-rewind (ForkOS _) = Just WillForkOS
-rewind (IsCurrentThreadBound _) = Just WillIsCurrentThreadBound
-rewind MyThreadId = Just WillMyThreadId
-rewind (GetNumCapabilities _) = Just WillGetNumCapabilities
-rewind (SetNumCapabilities i) = Just (WillSetNumCapabilities i)
-rewind Yield = Just WillYield
-rewind (ThreadDelay n) = Just (WillThreadDelay n)
-rewind (NewMVar _) = Just WillNewMVar
-rewind (PutMVar c _) = Just (WillPutMVar c)
-rewind (BlockedPutMVar c) = Just (WillPutMVar c)
-rewind (TryPutMVar c _ _) = Just (WillTryPutMVar c)
-rewind (ReadMVar c) = Just (WillReadMVar c)
-rewind (BlockedReadMVar c) = Just (WillReadMVar c)
-rewind (TryReadMVar c _) = Just (WillTryReadMVar c)
-rewind (TakeMVar c _) = Just (WillTakeMVar c)
-rewind (BlockedTakeMVar c) = Just (WillTakeMVar c)
-rewind (TryTakeMVar c _ _) = Just (WillTryTakeMVar c)
-rewind (NewCRef _) = Just WillNewCRef
-rewind (ReadCRef c) = Just (WillReadCRef c)
-rewind (ReadCRefCas c) = Just (WillReadCRefCas c)
-rewind (ModCRef c) = Just (WillModCRef c)
-rewind (ModCRefCas c) = Just (WillModCRefCas c)
-rewind (WriteCRef c) = Just (WillWriteCRef c)
-rewind (CasCRef c _) = Just (WillCasCRef c)
-rewind (CommitCRef t c) = Just (WillCommitCRef t c)
-rewind (STM _ _) = Just WillSTM
-rewind (BlockedSTM _) = Just WillSTM
-rewind Catching = Just WillCatching
-rewind PopCatching = Just WillPopCatching
-rewind Throw = Just WillThrow
-rewind (ThrowTo t) = Just (WillThrowTo t)
-rewind (BlockedThrowTo t) = Just (WillThrowTo t)
-rewind Killed = Nothing
-rewind (SetMasking b m) = Just (WillSetMasking b m)
-rewind (ResetMasking b m) = Just (WillResetMasking b m)
-rewind LiftIO = Just WillLiftIO
-rewind Return = Just WillReturn
-rewind Stop = Just WillStop
-rewind Subconcurrency = Just WillSubconcurrency
-rewind StopSubconcurrency = Just WillStopSubconcurrency
-rewind (DontCheck _) = Just WillDontCheck
+-- happened.
+rewind :: ThreadAction -> Lookahead
+rewind (Fork _) = WillFork
+rewind (ForkOS _) = WillForkOS
+rewind (IsCurrentThreadBound _) = WillIsCurrentThreadBound
+rewind MyThreadId = WillMyThreadId
+rewind (GetNumCapabilities _) = WillGetNumCapabilities
+rewind (SetNumCapabilities i) = WillSetNumCapabilities i
+rewind Yield = WillYield
+rewind (ThreadDelay n) = WillThreadDelay n
+rewind (NewMVar _) = WillNewMVar
+rewind (PutMVar c _) = WillPutMVar c
+rewind (BlockedPutMVar c) = WillPutMVar c
+rewind (TryPutMVar c _ _) = WillTryPutMVar c
+rewind (ReadMVar c) = WillReadMVar c
+rewind (BlockedReadMVar c) = WillReadMVar c
+rewind (TryReadMVar c _) = WillTryReadMVar c
+rewind (TakeMVar c _) = WillTakeMVar c
+rewind (BlockedTakeMVar c) = WillTakeMVar c
+rewind (TryTakeMVar c _ _) = WillTryTakeMVar c
+rewind (NewCRef _) = WillNewCRef
+rewind (ReadCRef c) = WillReadCRef c
+rewind (ReadCRefCas c) = WillReadCRefCas c
+rewind (ModCRef c) = WillModCRef c
+rewind (ModCRefCas c) = WillModCRefCas c
+rewind (WriteCRef c) = WillWriteCRef c
+rewind (CasCRef c _) = WillCasCRef c
+rewind (CommitCRef t c) = WillCommitCRef t c
+rewind (STM _ _) = WillSTM
+rewind (BlockedSTM _) = WillSTM
+rewind Catching = WillCatching
+rewind PopCatching = WillPopCatching
+rewind Throw = WillThrow
+rewind (ThrowTo t) = WillThrowTo t
+rewind (BlockedThrowTo t) = WillThrowTo t
+rewind (SetMasking b m) = WillSetMasking b m
+rewind (ResetMasking b m) = WillResetMasking b m
+rewind LiftIO = WillLiftIO
+rewind Return = WillReturn
+rewind Stop = WillStop
+rewind Subconcurrency = WillSubconcurrency
+rewind StopSubconcurrency = WillStopSubconcurrency
+rewind (DontCheck _) = WillDontCheck
 
 -- | Check if an operation could enable another thread.
 willRelease :: Lookahead -> Bool
@@ -303,7 +302,7 @@ tidsOf _ = S.empty
 -- This is used in the SCT code to help determine interesting
 -- alternative scheduling decisions.
 simplifyAction :: ThreadAction -> ActionType
-simplifyAction = maybe UnsynchronisedOther simplifyLookahead . rewind
+simplifyAction = simplifyLookahead . rewind
 
 -- | Variant of 'simplifyAction' that takes a 'Lookahead'.
 simplifyLookahead :: Lookahead -> ActionType

--- a/dejafu/Test/DejaFu/SCT.hs
+++ b/dejafu/Test/DejaFu/SCT.hs
@@ -37,7 +37,6 @@ module Test.DejaFu.SCT
 import           Control.Applicative               ((<|>))
 import           Control.DeepSeq                   (NFData(..), force)
 import           Control.Monad.Conc.Class          (MonadConc)
-import           Control.Monad.Ref                 (MonadRef)
 import           Data.List                         (foldl')
 import qualified Data.Map.Strict                   as M
 import           Data.Maybe                        (fromMaybe)
@@ -64,12 +63,12 @@ import           Test.DejaFu.Utils
 -- found, is unspecified and may change between releases.
 --
 -- @since 1.0.0.0
-runSCT :: (MonadConc n, MonadRef r n)
+runSCT :: MonadConc n
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
 runSCT way = runSCTWithSettings . fromWayAndMemType way
@@ -77,12 +76,12 @@ runSCT way = runSCTWithSettings . fromWayAndMemType way
 -- | Return the set of results of a concurrent program.
 --
 -- @since 1.0.0.0
-resultsSet :: (MonadConc n, MonadRef r n, Ord a)
+resultsSet :: (MonadConc n, Ord a)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n (Set (Either Failure a))
 resultsSet way = resultsSetWithSettings . fromWayAndMemType way
@@ -93,14 +92,14 @@ resultsSet way = resultsSetWithSettings . fromWayAndMemType way
 -- found, is unspecified and may change between releases.
 --
 -- @since 1.0.0.0
-runSCTDiscard :: (MonadConc n, MonadRef r n)
+runSCTDiscard :: MonadConc n
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> Way
   -- ^ How to run the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
 runSCTDiscard discard way = runSCTWithSettings . set ldiscard (Just discard) . fromWayAndMemType way
@@ -109,14 +108,14 @@ runSCTDiscard discard way = runSCTWithSettings . set ldiscard (Just discard) . f
 -- | A variant of 'resultsSet' which can selectively discard results.
 --
 -- @since 1.0.0.0
-resultsSetDiscard :: (MonadConc n, MonadRef r n, Ord a)
+resultsSetDiscard :: (MonadConc n, Ord a)
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.  Traces are always discarded.
   -> Way
   -- ^ How to run the concurrent program.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n (Set (Either Failure a))
 resultsSetDiscard discard way memtype conc =
@@ -133,8 +132,8 @@ resultsSetDiscard discard way memtype conc =
 -- found, is unspecified and may change between releases.
 --
 -- @since 1.0.0.0
-runSCT' :: (MonadConc n, MonadRef r n, NFData a)
-  => Way -> MemType -> ConcT r n a -> n [(Either Failure a, Trace)]
+runSCT' :: (MonadConc n, NFData a)
+  => Way -> MemType -> ConcT n a -> n [(Either Failure a, Trace)]
 runSCT' way = runSCTWithSettings' . fromWayAndMemType way
 
 -- | A strict variant of 'resultsSet'.
@@ -143,8 +142,8 @@ runSCT' way = runSCTWithSettings' . fromWayAndMemType way
 -- may be more efficient in some situations.
 --
 -- @since 1.0.0.0
-resultsSet' :: (MonadConc n, MonadRef r n, Ord a, NFData a)
-  => Way -> MemType -> ConcT r n a -> n (Set (Either Failure a))
+resultsSet' :: (MonadConc n, Ord a, NFData a)
+  => Way -> MemType -> ConcT n a -> n (Set (Either Failure a))
 resultsSet' way = resultsSetWithSettings' . fromWayAndMemType way
 
 -- | A strict variant of 'runSCTDiscard'.
@@ -156,8 +155,8 @@ resultsSet' way = resultsSetWithSettings' . fromWayAndMemType way
 -- found, is unspecified and may change between releases.
 --
 -- @since 1.0.0.0
-runSCTDiscard' :: (MonadConc n, MonadRef r n, NFData a)
-  => (Either Failure a -> Maybe Discard) -> Way -> MemType -> ConcT r n a -> n [(Either Failure a, Trace)]
+runSCTDiscard' :: (MonadConc n, NFData a)
+  => (Either Failure a -> Maybe Discard) -> Way -> MemType -> ConcT n a -> n [(Either Failure a, Trace)]
 runSCTDiscard' discard way memtype conc = do
   res <- runSCTDiscard discard way memtype conc
   rnf res `seq` pure res
@@ -169,8 +168,8 @@ runSCTDiscard' discard way memtype conc = do
 -- may be more efficient in some situations.
 --
 -- @since 1.0.0.0
-resultsSetDiscard' :: (MonadConc n, MonadRef r n, Ord a, NFData a)
-  => (Either Failure a -> Maybe Discard) -> Way -> MemType -> ConcT r n a -> n (Set (Either Failure a))
+resultsSetDiscard' :: (MonadConc n, Ord a, NFData a)
+  => (Either Failure a -> Maybe Discard) -> Way -> MemType -> ConcT n a -> n (Set (Either Failure a))
 resultsSetDiscard' discard way memtype conc = do
   res <- resultsSetDiscard discard way memtype conc
   rnf res `seq` pure res
@@ -185,10 +184,10 @@ resultsSetDiscard' discard way memtype conc = do
 -- found, is unspecified and may change between releases.
 --
 -- @since 1.2.0.0
-runSCTWithSettings :: (MonadConc n, MonadRef r n)
+runSCTWithSettings :: MonadConc n
   => Settings n a
   -- ^ The SCT settings.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
 runSCTWithSettings settings conc = case _way settings of
@@ -240,10 +239,10 @@ runSCTWithSettings settings conc = case _way settings of
 -- | A variant of 'resultsSet' which takes a 'Settings' record.
 --
 -- @since 1.2.0.0
-resultsSetWithSettings :: (MonadConc n, MonadRef r n, Ord a)
+resultsSetWithSettings :: (MonadConc n, Ord a)
   => Settings n a
   -- ^ The SCT settings.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n (Set (Either Failure a))
 resultsSetWithSettings settings conc =
@@ -259,9 +258,9 @@ resultsSetWithSettings settings conc =
 -- found, is unspecified and may change between releases.
 --
 -- @since 1.2.0.0
-runSCTWithSettings' :: (MonadConc n, MonadRef r n, NFData a)
+runSCTWithSettings' :: (MonadConc n, NFData a)
   => Settings n a
-  -> ConcT r n a
+  -> ConcT n a
   -> n [(Either Failure a, Trace)]
 runSCTWithSettings' settings conc = do
   res <- runSCTWithSettings settings conc
@@ -273,9 +272,9 @@ runSCTWithSettings' settings conc = do
 -- may be more efficient in some situations.
 --
 -- @since 1.2.0.0
-resultsSetWithSettings' :: (MonadConc n, MonadRef r n, Ord a, NFData a)
+resultsSetWithSettings' :: (MonadConc n, Ord a, NFData a)
   => Settings n a
-  -> ConcT r n a
+  -> ConcT n a
   -> n (Set (Either Failure a))
 resultsSetWithSettings' settings conc = do
   res <- resultsSetWithSettings settings conc
@@ -384,12 +383,12 @@ lBacktrack = backtrackAt (\_ _ -> False)
 -- found, is unspecified and may change between releases.
 --
 -- @since 1.0.0.0
-sctBound :: (MonadConc n, MonadRef r n)
+sctBound :: MonadConc n
   => MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> Bounds
   -- ^ The combined bounds.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times
   -> n [(Either Failure a, Trace)]
 sctBound = sctBoundDiscard (const Nothing)
@@ -401,14 +400,14 @@ sctBound = sctBoundDiscard (const Nothing)
 -- found, is unspecified and may change between releases.
 --
 -- @since 1.0.0.0
-sctBoundDiscard :: (MonadConc n, MonadRef r n)
+sctBoundDiscard :: MonadConc n
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> Bounds
   -- ^ The combined bounds.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times
   -> n [(Either Failure a, Trace)]
 sctBoundDiscard discard memtype cb = runSCTWithSettings $
@@ -423,14 +422,14 @@ sctBoundDiscard discard memtype cb = runSCTWithSettings $
 -- This is not guaranteed to find all distinct results.
 --
 -- @since 1.0.0.0
-sctUniformRandom :: (MonadConc n, MonadRef r n, RandomGen g)
+sctUniformRandom :: (MonadConc n, RandomGen g)
   => MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> g
   -- ^ The random number generator.
   -> Int
   -- ^ The number of executions to perform.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
 sctUniformRandom = sctUniformRandomDiscard (const Nothing)
@@ -442,7 +441,7 @@ sctUniformRandom = sctUniformRandomDiscard (const Nothing)
 -- This is not guaranteed to find all distinct results.
 --
 -- @since 1.0.0.0
-sctUniformRandomDiscard :: (MonadConc n, MonadRef r n, RandomGen g)
+sctUniformRandomDiscard :: (MonadConc n, RandomGen g)
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> MemType
@@ -451,7 +450,7 @@ sctUniformRandomDiscard :: (MonadConc n, MonadRef r n, RandomGen g)
   -- ^ The random number generator.
   -> Int
   -- ^ The number of executions to perform.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
 sctUniformRandomDiscard discard memtype g lim = runSCTWithSettings $
@@ -466,7 +465,7 @@ sctUniformRandomDiscard discard memtype g lim = runSCTWithSettings $
 -- This is not guaranteed to find all distinct results.
 --
 -- @since 1.0.0.0
-sctWeightedRandom :: (MonadConc n, MonadRef r n, RandomGen g)
+sctWeightedRandom :: (MonadConc n, RandomGen g)
   => MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
   -> g
@@ -475,7 +474,7 @@ sctWeightedRandom :: (MonadConc n, MonadRef r n, RandomGen g)
   -- ^ The number of executions to perform.
   -> Int
   -- ^ The number of executions to use the same set of weights for.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
 sctWeightedRandom = sctWeightedRandomDiscard (const Nothing)
@@ -487,7 +486,7 @@ sctWeightedRandom = sctWeightedRandomDiscard (const Nothing)
 -- This is not guaranteed to find all distinct results.
 --
 -- @since 1.0.0.0
-sctWeightedRandomDiscard :: (MonadConc n, MonadRef r n, RandomGen g)
+sctWeightedRandomDiscard :: (MonadConc n, RandomGen g)
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> MemType
@@ -498,7 +497,7 @@ sctWeightedRandomDiscard :: (MonadConc n, MonadRef r n, RandomGen g)
   -- ^ The number of executions to perform.
   -> Int
   -- ^ The number of executions to use the same set of weights for.
-  -> ConcT r n a
+  -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
 sctWeightedRandomDiscard discard memtype g lim use = runSCTWithSettings $

--- a/dejafu/Test/DejaFu/SCT/Internal.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal.hs
@@ -16,7 +16,6 @@
 module Test.DejaFu.SCT.Internal where
 
 import           Control.Monad.Conc.Class         (MonadConc)
-import           Control.Monad.Ref                (MonadRef)
 import           Data.Coerce                      (Coercible, coerce)
 import qualified Data.IntMap.Strict               as I
 import           Data.List                        (find, mapAccumL)
@@ -35,7 +34,7 @@ import           Test.DejaFu.Utils
 -- * Exploration
 
 -- | General-purpose SCT function.
-sct :: (MonadConc n, MonadRef r n)
+sct :: MonadConc n
   => Settings n a
   -- ^ The SCT settings ('Way' is ignored)
   -> ([ThreadId] -> s)
@@ -44,7 +43,7 @@ sct :: (MonadConc n, MonadRef r n)
   -- ^ State predicate
   -> ((Scheduler g -> g -> n (Either Failure a, g, Trace)) -> s -> t -> n (s, Maybe (Either Failure a, Trace)))
   -- ^ Run the computation and update the state
-  -> ConcT r n a
+  -> ConcT n a
   -> n [(Either Failure a, Trace)]
 sct settings s0 sfun srun conc
     | canDCSnapshot conc = runForDCSnapshot conc >>= \case
@@ -80,7 +79,7 @@ sct settings s0 sfun srun conc
     debugPrint = fromMaybe (const (pure ())) (_debugPrint settings)
 
 -- | Like 'sct' but given a function to run the computation.
-sct' :: (MonadConc n, MonadRef r n)
+sct' :: MonadConc n
   => Settings n a
   -- ^ The SCT settings ('Way' is ignored)
   -> s
@@ -147,7 +146,7 @@ sct' settings s0 sfun srun run nextTId nextCRId = go Nothing [] s0 where
 -- Unlike shrinking in randomised property-testing tools like
 -- QuickCheck or Hedgehog, we only run the test case /once/, at the
 -- end, rather than after every simplification step.
-simplifyExecution :: (MonadConc n, MonadRef r n)
+simplifyExecution :: MonadConc n
   => Settings n a
   -- ^ The SCT settings ('Way' is ignored)
   -> (forall x. Scheduler x -> x -> n (Either Failure a, x, Trace))
@@ -185,7 +184,7 @@ simplifyExecution settings run nextTId nextCRId res trace
     p = either show debugShow
 
 -- | Replay an execution.
-replay :: (MonadConc n, MonadRef r n)
+replay :: MonadConc n
   => (forall x. Scheduler x -> x -> n (Either Failure a, x, Trace))
   -- ^ Run the computation
   -> [(ThreadId, ThreadAction)]

--- a/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
@@ -578,6 +578,8 @@ dependent ds t1 a1 t2 a2 = case (a1, a2) of
   -- actually blocked. 'dependent'' has to assume that all
   -- potentially-blocking operations can block, and so is more
   -- pessimistic in this case.
+  (ThrowTo t, ThrowTo u)
+    | t == t2 && u == t1 -> canInterrupt ds t1 a1 || canInterrupt ds t2 a2
   (ThrowTo t, _) | t == t2 -> canInterrupt ds t2 a2 && a2 /= Stop
   (_, ThrowTo t) | t == t1 -> canInterrupt ds t1 a1 && a1 /= Stop
 
@@ -611,6 +613,8 @@ dependent' ds t1 a1 t2 l2 = case (a1, l2) of
   -- thread and if the actions can be interrupted. We can also
   -- slightly improve on that by not considering interrupting the
   -- normal termination of a thread: it doesn't make a difference.
+  (ThrowTo t, WillThrowTo u)
+    | t == t2 && u == t1 -> canInterrupt ds t1 a1 || canInterruptL ds t2 l2
   (ThrowTo t, _)     | t == t2 -> canInterruptL ds t2 l2 && l2 /= WillStop
   (_, WillThrowTo t) | t == t1 -> canInterrupt  ds t1 a1 && a1 /= Stop
 

--- a/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
@@ -589,9 +589,8 @@ dependent ds t1 a1 t2 a2 = case (a1, a2) of
   (BlockedSTM _, STM _ _)      -> checkSTM
   (BlockedSTM _, BlockedSTM _) -> checkSTM
 
-  _ -> case (,) <$> rewind a1 <*> rewind a2 of
-    Just (l1, l2) -> dependent' ds t1 a1 t2 l2 && dependent' ds t2 a2 t1 l1
-    _ -> dependentActions ds (simplifyAction a1) (simplifyAction a2)
+  _ -> dependent' ds t1 a1 t2 (rewind a2)
+    && dependent' ds t2 a2 t1 (rewind a1)
 
   where
     -- STM actions A and B are dependent if A wrote to anything B

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -104,7 +104,7 @@ initialThread = ThreadId (Id (Just "main") 0)
 
 -- | All the actions that a thread can perform.
 --
--- @since unreleased
+-- @since 1.4.0.0
 data ThreadAction =
     Fork ThreadId
   -- ^ Start a new thread.

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -104,7 +104,7 @@ initialThread = ThreadId (Id (Just "main") 0)
 
 -- | All the actions that a thread can perform.
 --
--- @since 1.1.0.0
+-- @since unreleased
 data ThreadAction =
     Fork ThreadId
   -- ^ Start a new thread.
@@ -175,8 +175,6 @@ data ThreadAction =
   -- ^ Throw an exception to a thread.
   | BlockedThrowTo ThreadId
   -- ^ Get blocked on a 'throwTo'.
-  | Killed
-  -- ^ Killed by an uncaught exception.
   | SetMasking Bool MaskingState
   -- ^ Set the masking state. If 'True', this is being used to set the
   -- masking state to the original state in the argument passed to a
@@ -238,7 +236,6 @@ instance NFData ThreadAction where
   rnf Throw = ()
   rnf (ThrowTo t) = rnf t
   rnf (BlockedThrowTo t) = rnf t
-  rnf Killed = ()
   rnf (SetMasking b m) = rnf (b, show m)
   rnf (ResetMasking b m) = rnf (b, show m)
   rnf LiftIO = ()

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -66,7 +66,6 @@ library
                      , leancheck         >=0.6 && <0.8
                      , profunctors       >=4.0 && <6.0
                      , random            >=1.0 && <1.2
-                     , ref-fd            >=0.4 && <0.5
                      , transformers      >=0.4 && <0.6
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.3.2.0
+version:             1.4.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.3.2.0
+  tag:      dejafu-1.4.0.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,9 +28,9 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.4.0.2", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.3.2.0", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "1.1.0.2", "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "1.1.0.1", "Déjà Fu support for the tasty test framework"
+   ":hackage:`dejafu`",       "1.4.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "1.1.0.3", "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "1.1.0.2", "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.1.0.3 (2018-03-17)
+--------------------
+
+* Git: :tag:`hunit-dejafu-1.1.0.3`
+* Hackage: :hackage:`hunit-dejafu-1.1.0.3`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* (:pull:`251`) The upper bound on :hackage:`dejafu` is <1.5.
+
+
 1.1.0.2 (2018-03-11)
 --------------------
 

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             1.1.0.2
+version:             1.1.0.3
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-1.1.0.2
+  tag:      hunit-dejafu-1.1.0.3
 
 library
   exposed-modules:     Test.HUnit.DejaFu
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.8 && <5
                      , exceptions >=0.7 && <0.11
-                     , dejafu     >=1.2 && <1.4
+                     , dejafu     >=1.2 && <1.5
                      , HUnit      >=1.2 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -6,6 +6,19 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+
+1.1.0.2 (2018-03-17)
+--------------------
+
+* Git: :tag:`tasty-dejafu-1.1.0.2`
+* Hackage: :hackage:`tasty-dejafu-1.1.0.2`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.5.
+
+
 1.1.0.1 (2018-03-06)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             1.1.0.1
+version:             1.1.0.2
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,14 +30,14 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-1.1.0.1
+  tag:      tasty-dejafu-1.1.0.2
 
 library
   exposed-modules:     Test.Tasty.DejaFu
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.8  && <5
-                     , dejafu >=1.2  && <1.4
+                     , dejafu >=1.2  && <1.5
                      , random >=1.0  && <1.2
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.1


### PR DESCRIPTION
## Summary

Mostly just refactoring, sadly backwards-incompatible, plus one bug fix.

**re 6be0ce9:**
I could have added a deprecated type synonym `ConcT r n a = NewType n a` or something, but I don't really see the point.  If someone is using `hunit-dejafu` or `tasty-dejafu`, they're using `ConcIO` anyway. 
 If they're writing explicit type signatures at all, that is; I expect most uses are of the form `MonadConc m => m a` and type inference is doing the rest.  Somewhat tellingly, I didn't have to change `dejafu-tests` at all to accommodate this change.

**re 8f0d339:**
The bug appeared in a Hedgehog test in an unrelated Travis job.  To search for similar hidden bugs, I ran the `Tests/Unit/Properties` tests 30,000 times (normally it only does 1500 runs).  Nothing new came up.

**Related issues:** closes #198, closes #201, closes #250 