### PR TITLE
Add weaken/strengthen monoids for discard functions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.5.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.5.0.0 | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 1.5.1.0 | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 1.2.0.0 | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 1.2.0.0 | Deja Fu support for the Tasty test framework. |
 

--- a/dejafu-tests/dejafu-tests.cabal
+++ b/dejafu-tests/dejafu-tests.cabal
@@ -49,6 +49,7 @@ library
                      , abstract-deque
                      , concurrency
                      , containers
+                     , contravariant
                      , deepseq
                      , dejafu
                      , exceptions

--- a/dejafu-tests/lib/Common.hs
+++ b/dejafu-tests/lib/Common.hs
@@ -189,6 +189,12 @@ genFunction genKey genVal = (,) <$> genVal <*> genSmallMap genKey genVal
 applyFunction :: Ord k => (v, Map.Map k v) -> k -> v
 applyFunction (def, assocs) k = Map.findWithDefault def k assocs
 
+genPair :: H.Gen a -> H.Gen (a, a)
+genPair g = (,) <$> g <*> g
+
+genEither :: H.Gen l -> H.Gen r -> H.Gen (Either l r)
+genEither l r = HGen.choice [Left <$> l, Right <$> r]
+
 -------------------------------------------------------------------------------
 -- Utilities
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.5.1.0 (2018-03-29)
+--------------------
+
+* Git: :tag:`dejafu-1.5.1.0`
+* Hackage: :hackage:`dejafu-1.5.1.0`
 
 Added
 ~~~~~

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Added
+~~~~~
+
+- (:issue:`210`) ``Test.DejaFu.Types.Weaken`` and ``Strengthen``
+  newtype wrappers around discard functions, with ``Semigroup``,
+  ``Monoid``, ``Contravariant``, and ``Divisible`` instances
+  corresponding to ``weakenDiscard`` and ``strengthenDiscard``.
+
+
 1.5.0.0 - No More 7.10 (2018-03-28)
 -----------------------------------
 

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -637,7 +637,7 @@ instance NFData Discard
 -- @Just DiscardResultAndTrace@.  This forms a commutative monoid
 -- where the unit is @const (Just DiscardResultAndTrace)@.
 --
--- @since unreleased
+-- @since 1.5.1.0
 newtype Weaken a = Weaken
   { getWeakDiscarder :: Either Failure a -> Maybe Discard }
 
@@ -677,7 +677,7 @@ weakenDiscard d1 d2 =
 -- which is stronger than @Nothing@.  This forms a commutative monoid
 -- where the unit is @const Nothing@.
 --
--- @since unreleased
+-- @since 1.5.1.0
 newtype Strengthen a = Strengthen
   { getStrongDiscarder :: Either Failure a -> Maybe Discard }
 

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -61,6 +61,7 @@ library
   build-depends:       base              >=4.9 && <5
                      , concurrency       >=1.5 && <1.6
                      , containers        >=0.5 && <0.6
+                     , contravariant     >=1.2 && <1.5
                      , deepseq           >=1.1 && <2
                      , exceptions        >=0.7 && <0.11
                      , leancheck         >=0.6 && <0.8

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.5.0.0
+version:             1.5.1.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.5.0.0
+  tag:      dejafu-1.5.1.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.5.0.0", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.5.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "1.5.1.0", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "1.2.0.0", "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "1.2.0.0", "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
## Summary

> `weakenDiscard` and `strengthenDiscard` each form a commutative monoid.  In fact, they correspond to the monoid operation which picks the least (or greatest) element, according to some ordering.  Each has a unit:
>
> - For `weakenDiscard` it's the strongest: `const (Just DiscardResultAndTrace)`
> - For `strengthenDiscard` it's the weakest: `const Nothing`
>
> [...]
>
> These could also serve as nice documentation, if presented well.  Perhaps we should even add newtype'd monoids!

This PR adds the newtype'd monoids, with a few other instances as well.  Adds a dependency on `contravariant`, but we pulled that in anyway via `profunctors`.

**Related issues:** closes #210

## Checklist

- [x] Add new tests to dejafu-tests