### PR TITLE
Remove swarmy

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,9 +46,9 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.5.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.6.0.0 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 1.2.0.1 | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 1.2.0.2 | Deja Fu support for the Tasty test framework. |
+| [dejafu][h:dejafu]       | 1.7.0.0 | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 1.2.0.2 | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 1.2.0.3 | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/dejafu-tests/lib/Common.hs
+++ b/dejafu-tests/lib/Common.hs
@@ -72,7 +72,6 @@ defaultWaysFor b =
   [ ("systematically", systematically b)
   , ("uniformly", uniformly (mkStdGen 0) 100)
   , ("randomly", randomly (mkStdGen 0) 100)
-  , ("swarmy", swarmy (mkStdGen 0) 100 10)
   ]
 
 testGroup :: IsTest t => String -> t -> T.TestTree

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,6 +6,23 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+unreleased
+----------
+
+Changed
+~~~~~~~
+
+* (:issue:`237`) ``Test.DejaFu.SCT.sctWeightedRandom`` and
+  ``sctWeightedRandomDiscard`` no longer take the number of executions
+  to use the same weights for as a parameter.
+
+Removed
+~~~~~~~
+
+* (:issue:`237`) The deprecated function
+  ``Test.DejaFu.Settings.swarmy``.
+
+
 1.6.0.0 (2018-05-11)
 --------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,8 +6,11 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
-unreleased
-----------
+1.7.0.0 (2018-06-03)
+--------------------
+
+* Git: :tag:`dejafu-1.7.0.0`
+* Hackage: :hackage:`dejafu-1.7.0.0`
 
 Changed
 ~~~~~~~

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -88,8 +88,7 @@ order.
 
 If you need to test things with /nondeterministc/ @IO@, see the
 'autocheckWay', 'dejafuWay', and 'dejafusWay' functions: the
-'randomly', 'uniformly', and 'swarmy' testing modes can cope with
-nondeterminism.
+'randomly' and 'uniformly' testing modes can cope with nondeterminism.
 -}
 module Test.DejaFu
   ( -- * Unit testing

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -52,13 +52,11 @@ data Settings n a = Settings
 -- @since 0.7.0.0
 data Way where
   Systematic :: Bounds -> Way
-  Weighted   :: RandomGen g => g -> Int -> Int -> Way
-  Uniform    :: RandomGen g => g -> Int -> Way
+  Randomly   :: RandomGen g => (g -> (Int, g)) -> g -> Int -> Way
 
 instance Show Way where
-  show (Systematic bs)  = "Systematic (" ++ show bs ++ ")"
-  show (Weighted _ n t) = "Weighted <gen> " ++ show (n, t)
-  show (Uniform  _ n)   = "Uniform <gen> " ++ show n
+  show (Systematic bs) = "Systematic (" ++ show bs ++ ")"
+  show (Randomly _ _ n) = "Randomly <f> <gen> " ++ show n
 
 -------------------------------------------------------------------------------
 -- * Identifiers

--- a/dejafu/Test/DejaFu/SCT.hs
+++ b/dejafu/Test/DejaFu/SCT.hs
@@ -44,7 +44,7 @@ import qualified Data.Map.Strict                   as M
 import           Data.Maybe                        (fromMaybe)
 import           Data.Set                          (Set)
 import qualified Data.Set                          as S
-import           System.Random                     (RandomGen, randomR)
+import           System.Random                     (RandomGen)
 
 import           Test.DejaFu.Conc
 import           Test.DejaFu.Internal
@@ -211,7 +211,7 @@ runSCTWithSettings settings conc = case _way settings of
                  else (force (incorporateBacktrackSteps bpoints newDPOR), Just (res, trace))
     in sct settings initial check step conc
 
-  Uniform g0 lim0 ->
+  Randomly gen g0 lim0 ->
     let initial _ = (g0, max 0 lim0)
 
         check (_, 0) = Nothing
@@ -219,23 +219,9 @@ runSCTWithSettings settings conc = case _way settings of
 
         step run _ (g, n) = do
           (res, s, trace) <- run
-            (randSched $ \g' -> (1, g'))
-            (initialRandSchedState Nothing g)
+            (randSched gen)
+            (initialRandSchedState g)
           pure ((schedGen s, n-1), Just (res, trace))
-    in sct settings initial check step conc
-
-  Weighted g0 lim0 use0 ->
-    let initial _ = (g0, max 0 lim0, max 1 use0, M.empty)
-
-        check (_, 0, _, _) = Nothing
-        check s = Just s
-
-        step run s (g, n, 0, _) = step run s (g, n, max 1 use0, M.empty)
-        step run _ (g, n, use, ws) = do
-          (res, s, trace) <- run
-            (randSched $ randomR (1, 50))
-            (initialRandSchedState (Just ws) g)
-          pure ((schedGen s, n-1, use-1, schedWeights s), Just (res, trace))
     in sct settings initial check step conc
 
 -- | A variant of 'resultsSet' which takes a 'Settings' record.
@@ -466,7 +452,7 @@ sctUniformRandomDiscard discard memtype g lim = runSCTWithSettings $
 --
 -- This is not guaranteed to find all distinct results.
 --
--- @since 1.0.0.0
+-- @since unreleased
 sctWeightedRandom :: (MonadConc n, RandomGen g)
   => MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
@@ -474,8 +460,6 @@ sctWeightedRandom :: (MonadConc n, RandomGen g)
   -- ^ The random number generator.
   -> Int
   -- ^ The number of executions to perform.
-  -> Int
-  -- ^ The number of executions to use the same set of weights for.
   -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
@@ -487,7 +471,7 @@ sctWeightedRandom = sctWeightedRandomDiscard (const Nothing)
 --
 -- This is not guaranteed to find all distinct results.
 --
--- @since 1.0.0.0
+-- @since unreleased
 sctWeightedRandomDiscard :: (MonadConc n, RandomGen g)
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.
@@ -497,13 +481,11 @@ sctWeightedRandomDiscard :: (MonadConc n, RandomGen g)
   -- ^ The random number generator.
   -> Int
   -- ^ The number of executions to perform.
-  -> Int
-  -- ^ The number of executions to use the same set of weights for.
   -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
-sctWeightedRandomDiscard discard memtype g lim use = runSCTWithSettings $
-  set ldiscard (Just discard) (fromWayAndMemType (swarmy g lim use) memtype)
+sctWeightedRandomDiscard discard memtype g lim = runSCTWithSettings $
+  set ldiscard (Just discard) (fromWayAndMemType (randomly g lim) memtype)
 {-# DEPRECATED sctWeightedRandomDiscard "Use runSCTWithSettings instead" #-}
 
 -------------------------------------------------------------------------------

--- a/dejafu/Test/DejaFu/SCT.hs
+++ b/dejafu/Test/DejaFu/SCT.hs
@@ -452,7 +452,7 @@ sctUniformRandomDiscard discard memtype g lim = runSCTWithSettings $
 --
 -- This is not guaranteed to find all distinct results.
 --
--- @since unreleased
+-- @since 1.7.0.0
 sctWeightedRandom :: (MonadConc n, RandomGen g)
   => MemType
   -- ^ The memory model to use for non-synchronised @CRef@ operations.
@@ -471,7 +471,7 @@ sctWeightedRandom = sctWeightedRandomDiscard (const Nothing)
 --
 -- This is not guaranteed to find all distinct results.
 --
--- @since unreleased
+-- @since 1.7.0.0
 sctWeightedRandomDiscard :: (MonadConc n, RandomGen g)
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.

--- a/dejafu/Test/DejaFu/SCT/Internal/Weighted.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/Weighted.hs
@@ -18,7 +18,6 @@ import           Control.DeepSeq      (NFData)
 import           Data.List.NonEmpty   (toList)
 import           Data.Map.Strict      (Map)
 import qualified Data.Map.Strict      as M
-import           Data.Maybe           (fromMaybe)
 import           GHC.Generics         (Generic)
 import           System.Random        (RandomGen, randomR)
 
@@ -37,8 +36,8 @@ data RandSchedState g = RandSchedState
   } deriving (Eq, Show, Generic, NFData)
 
 -- | Initial weighted random scheduler state.
-initialRandSchedState :: Maybe (Map ThreadId Int) -> g -> RandSchedState g
-initialRandSchedState = RandSchedState . fromMaybe M.empty
+initialRandSchedState :: g -> RandSchedState g
+initialRandSchedState = RandSchedState M.empty
 
 -- | Weighted random scheduler: assigns to each new thread a weight,
 -- and makes a weighted random choice out of the runnable threads at

--- a/dejafu/Test/DejaFu/Settings.hs
+++ b/dejafu/Test/DejaFu/Settings.hs
@@ -207,14 +207,11 @@ module Test.DejaFu.Settings
   -- * Lens helpers
   , get
   , set
-
-  -- * Deprecated
-  , swarmy
   ) where
 
 import           Control.Applicative   (Const(..))
 import           Data.Functor.Identity (Identity(..))
-import           System.Random         (RandomGen)
+import           System.Random         (RandomGen, randomR)
 
 import           Test.DejaFu.Internal  (Settings(..), Way(..))
 import           Test.DejaFu.Types
@@ -288,7 +285,7 @@ randomly :: RandomGen g
   -> Int
   -- ^ The number of executions to try.
   -> Way
-randomly g lim = Weighted g lim 1
+randomly = Randomly $ randomR (1, 50)
 
 -- | Randomly execute a program, exploring a fixed number of
 -- executions.
@@ -305,29 +302,7 @@ uniformly :: RandomGen g
   -> Int
   -- ^ The number of executions to try.
   -> Way
-uniformly = Uniform
-
--- | Randomly execute a program, exploring a fixed number of
--- executions.
---
--- Threads are scheduled by a weighted random selection, where weights
--- are assigned randomly on thread creation.
---
--- This is not guaranteed to find all distinct results (unlike
--- 'systematically').
---
--- @since 0.7.0.0
-swarmy :: RandomGen g
-  => g
-  -- ^ The random generator to drive the scheduling.
-  -> Int
-  -- ^ The number of executions to try.
-  -> Int
-  -- ^ The number of executions to use the thread weights for.
-  -> Way
--- when this is removed, simplify the Weighted logic to not do re-use
-swarmy = Weighted
-{-# DEPRECATED swarmy "Use randomly instead.  If you have a case where swarmy works better, please comment on issue #237." #-}
+uniformly = Randomly $ \g -> (1, g)
 
 -------------------------------------------------------------------------------
 -- Schedule bounds

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.6.0.0
+version:             1.7.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.6.0.0
+  tag:      dejafu-1.7.0.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -142,10 +142,6 @@ There are three variants:
   Like ``randomly``, but rather than a weighted selection, it's a
   uniform selection.
 
-``swarmy randomGen numExecutions numUses``
-  Like ``randomly``, but each set of thread weights is used for
-  ``numUses`` executions.
-
 These are all given as the first argument to ``dejafuWay`` (and its
 ilk), like ``systematically``.  So for example you could do this:
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,9 +28,9 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.5.0.0", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.6.0.0", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "1.2.0.1", "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "1.2.0.2", "Déjà Fu support for the tasty test framework"
+   ":hackage:`dejafu`",       "1.7.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "1.2.0.2", "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "1.2.0.3", "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.0.2 (2018-06-03)
+--------------------
+
+* Git: :tag:`hunit-dejafu-1.2.0.2`
+* Hackage: :hackage:`hunit-dejafu-1.2.0.2`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.8.
+
+
 1.2.0.1 (2018-05-11)
 --------------------
 

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             1.2.0.1
+version:             1.2.0.2
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-1.2.0.1
+  tag:      hunit-dejafu-1.2.0.2
 
 library
   exposed-modules:     Test.HUnit.DejaFu
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.9 && <5
                      , exceptions >=0.7 && <0.11
-                     , dejafu     >=1.5 && <1.7
+                     , dejafu     >=1.5 && <1.8
                      , HUnit      >=1.3.1 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.0.3 (2018-06-03)
+--------------------
+
+* Git: :tag:`tasty-dejafu-1.2.0.3`
+* Hackage: :hackage:`tasty-dejafu-1.2.0.3`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.8.
+
+
 1.2.0.2 (2018-05-12)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             1.2.0.2
+version:             1.2.0.3
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,14 +30,14 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-1.2.0.2
+  tag:      tasty-dejafu-1.2.0.3
 
 library
   exposed-modules:     Test.Tasty.DejaFu
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.9  && <5
-                     , dejafu >=1.5  && <1.7
+                     , dejafu >=1.5  && <1.8
                      , random >=1.0  && <1.2
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.2


### PR DESCRIPTION
## Summary

Removes `swarmy`, and simplifies the random SCT logic.

**Related issues:** closes #237
