### PR TITLE
Disable length bounding by default

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,9 +46,9 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.5.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.7.0.0 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 1.2.0.2 | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 1.2.0.3 | Deja Fu support for the Tasty test framework. |
+| [dejafu][h:dejafu]       | 1.8.0.0 | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 1.2.0.3 | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 1.2.0.4 | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/dejafu-tests/lib/Examples/ParMonad.hs
+++ b/dejafu-tests/lib/Examples/ParMonad.hs
@@ -3,7 +3,7 @@ module Examples.ParMonad where
 import           Control.Monad.Conc.Class (MonadConc)
 import           Control.Monad.IO.Class   (MonadIO)
 import           System.Random            (mkStdGen)
-import           Test.DejaFu              (deadlocksNever, deadlocksSometimes)
+import           Test.DejaFu              (deadlocksSometimes)
 
 import qualified Examples.ParMonad.Direct as Par
 
@@ -12,7 +12,7 @@ import           Common
 tests :: [TestTree]
 tests = toTestList
   [ W "random testing exposes a deadlock" parFilter deadlocksSometimes ("randomly", randomly (mkStdGen 0) 150)
-  , W "systematic testing does not" parFilter deadlocksNever ("systematically", systematically defaultBounds)
+  , W "so does systematic testing" parFilter deadlocksSometimes ("systematically", systematically defaultBounds)
   ]
 
 parFilter :: (MonadConc m, MonadIO m) => m Bool

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,6 +6,17 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+
+unreleased
+----------
+
+Changed
+~~~~~~~
+
+* (:issue:`258`) Length bounding is disabled by default.  This is not
+  a breaking API change, but it is a breaking semantics change.
+
+
 1.7.0.0 (2018-06-03)
 --------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.8.0.0 (2018-06-03)
+--------------------
+
+* Git: :tag:`dejafu-1.8.0.0`
+* Hackage: :hackage:`dejafu-1.8.0.0`
 
 Changed
 ~~~~~~~

--- a/dejafu/Test/DejaFu/Settings.hs
+++ b/dejafu/Test/DejaFu/Settings.hs
@@ -309,12 +309,15 @@ uniformly = Randomly $ \g -> (1, g)
 
 -- | All bounds enabled, using their default values.
 --
--- @since 0.2.0.0
+-- There is no default length bound, so set one if your computation
+-- may not terminate!
+--
+-- @since unreleased
 defaultBounds :: Bounds
 defaultBounds = Bounds
   { boundPreemp = Just defaultPreemptionBound
   , boundFair   = Just defaultFairBound
-  , boundLength = Just defaultLengthBound
+  , boundLength = Nothing
   }
 
 -- | A sensible default preemption bound: 2.
@@ -335,12 +338,11 @@ defaultPreemptionBound = 2
 defaultFairBound :: FairBound
 defaultFairBound = 5
 
--- | A sensible default length bound: 250.
+-- | There is no default length bound.
 --
--- Based on the assumption that anything which executes for much
--- longer (or even this long) will take ages to test.
+-- This is only suitable if your computation will always terminate!
 --
--- @since 0.2.0.0
+-- @since unreleased
 defaultLengthBound :: LengthBound
 defaultLengthBound = 250
 

--- a/dejafu/Test/DejaFu/Settings.hs
+++ b/dejafu/Test/DejaFu/Settings.hs
@@ -312,7 +312,7 @@ uniformly = Randomly $ \g -> (1, g)
 -- There is no default length bound, so set one if your computation
 -- may not terminate!
 --
--- @since unreleased
+-- @since 1.8.0.0
 defaultBounds :: Bounds
 defaultBounds = Bounds
   { boundPreemp = Just defaultPreemptionBound
@@ -342,7 +342,7 @@ defaultFairBound = 5
 --
 -- This is only suitable if your computation will always terminate!
 --
--- @since unreleased
+-- @since 1.8.0.0
 defaultLengthBound :: LengthBound
 defaultLengthBound = 250
 

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.7.0.0
+version:             1.8.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.7.0.0
+  tag:      dejafu-1.8.0.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,9 +28,9 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.5.0.0", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.7.0.0", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "1.2.0.2", "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "1.2.0.3", "Déjà Fu support for the tasty test framework"
+   ":hackage:`dejafu`",       "1.8.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "1.2.0.3", "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "1.2.0.4", "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.0.3 (2018-06-03)
+--------------------
+
+* Git: :tag:`hunit-dejafu-1.2.0.3`
+* Hackage: :hackage:`hunit-dejafu-1.2.0.3`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.9.
+
+
 1.2.0.2 (2018-06-03)
 --------------------
 

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             1.2.0.2
+version:             1.2.0.3
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-1.2.0.2
+  tag:      hunit-dejafu-1.2.0.3
 
 library
   exposed-modules:     Test.HUnit.DejaFu
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.9 && <5
                      , exceptions >=0.7 && <0.11
-                     , dejafu     >=1.5 && <1.8
+                     , dejafu     >=1.5 && <1.9
                      , HUnit      >=1.3.1 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.0.4 (2018-06-03)
+--------------------
+
+* Git: :tag:`tasty-dejafu-1.2.0.4`
+* Hackage: :hackage:`tasty-dejafu-1.2.0.4`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.9.
+
+
 1.2.0.3 (2018-06-03)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             1.2.0.3
+version:             1.2.0.4
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,14 +30,14 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-1.2.0.3
+  tag:      tasty-dejafu-1.2.0.4
 
 library
   exposed-modules:     Test.Tasty.DejaFu
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.9  && <5
-                     , dejafu >=1.5  && <1.8
+                     , dejafu >=1.5  && <1.9
                      , random >=1.0  && <1.2
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.2


### PR DESCRIPTION
## Summary

Sets the default length bound to `Nothing`.

I'm giving this a major version bump even though it's not a breaking API change, because it is a breaking semantics change.

**Related issues:** closes #258