### PR TITLE
Highlight failures in tests

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -9,6 +9,12 @@
 # Record patterns are just ugly.
 - ignore: {name: Use record patterns}
 
+# Don't prefer TupleSections
+- ignore: {name: Use tuple-section}
+
+# Inapplicable
+- ignore: {name: Use readTVarIO, within: Control.Monad.Conc.Class}
+
 # GHC treats infix $ specially wrt type checking, so that things like
 # "runST $ do ..." work even though they're impredicative.
 # Unfortunately, this means that HLint's "avoid lambda" warning for

--- a/README.markdown
+++ b/README.markdown
@@ -45,10 +45,10 @@ There are a few different packages under the Déjà Fu umbrella:
 
 |   | Version | Summary |
 | - | ------- | ------- |
-| [concurrency][h:conc]    | 1.5.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.9.1.0 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 1.2.0.4 | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 1.2.0.5 | Deja Fu support for the Tasty test framework. |
+| [concurrency][h:conc]    | 1.5.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
+| [dejafu][h:dejafu]       | 1.10.0.0 | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 1.2.0.5  | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 1.2.0.6  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/dejafu-tests/dejafu-tests.cabal
+++ b/dejafu-tests/dejafu-tests.cabal
@@ -18,6 +18,7 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Unit
+                     , Unit.Predicates
                      , Unit.Properties
 
                      , Integration

--- a/dejafu-tests/lib/Examples/SearchParty.hs
+++ b/dejafu-tests/lib/Examples/SearchParty.hs
@@ -42,7 +42,7 @@ concFilter = unsafeRunFind $ [0..5] @! const True
 
 -- | Check that two lists of results are equal, modulo order.
 checkResultLists :: Ord a => Predicate [a]
-checkResultLists = alwaysSameOn (fmap sort)
+checkResultLists = alwaysSameOn sort
 
 -------------------------------------------------------------------------------
 

--- a/dejafu-tests/lib/Integration/MultiThreaded.hs
+++ b/dejafu-tests/lib/Integration/MultiThreaded.hs
@@ -178,7 +178,7 @@ stmTests = toTestList
   [ djfuT "Transactions are atomic" (gives' [0,2]) $ do
       x <- atomically $ newTVarInt 0
       _ <- fork . atomically $ writeTVar x 1 >> writeTVar x 2
-      atomically $ readTVar x
+      readTVarConc x
 
   , djfuT "'retry' is the left identity of 'orElse'" (gives' [()]) $ do
       x <- atomically $ newTVar Nothing

--- a/dejafu-tests/lib/Integration/Regressions.hs
+++ b/dejafu-tests/lib/Integration/Regressions.hs
@@ -45,7 +45,7 @@ tests = toTestList
         writeTVar v 2
         writeTVar v 3
         retry
-      atomically $ readTVar v
+      readTVarConc v
 
   , djfu "https://github.com/barrucadu/dejafu/issues/118" exceptionsAlways $
       catchSomeException

--- a/dejafu-tests/lib/Integration/SingleThreaded.hs
+++ b/dejafu-tests/lib/Integration/SingleThreaded.hs
@@ -139,7 +139,7 @@ stmTests = toTestList
 
   , djfu "When a TVar is updated, its new value is visible in a later transaction" (gives' [True]) $ do
       ctv <- atomically $ newTVarInt 5
-      (5==) <$> atomically (readTVar ctv)
+      (5==) <$> readTVarConc ctv
 
   , djfu "Aborting a transaction blocks the thread" (gives [Left STMDeadlock])
       (atomically retry :: MonadConc m => m ()) -- avoid an ambiguous type
@@ -147,14 +147,14 @@ stmTests = toTestList
   , djfu "Aborting a transaction can be caught and recovered from" (gives' [True]) $ do
       ctv <- atomically $ newTVarInt 5
       atomically $ orElse retry (writeTVar ctv 6)
-      (6==) <$> atomically (readTVar ctv)
+      (6==) <$> readTVarConc ctv
 
   , djfu "An exception thrown in a transaction can be caught" (gives' [True]) $ do
       ctv <- atomically $ newTVarInt 5
       atomically $ catchArithException
         (throwSTM Overflow)
         (\_ -> writeTVar ctv 6)
-      (6==) <$> atomically (readTVar ctv)
+      (6==) <$> readTVarConc ctv
 
   , djfu "Nested exception handlers in transactions work" (gives' [True]) $ do
       ctv <- atomically $ newTVarInt 5
@@ -163,7 +163,7 @@ stmTests = toTestList
           (throwSTM Overflow)
           (\_ -> writeTVar ctv 0))
         (\_ -> writeTVar ctv 6)
-      (6==) <$> atomically (readTVar ctv)
+      (6==) <$> readTVarConc ctv
 
   , djfu "MonadSTM is a MonadFail" (alwaysFailsWith isUncaughtException)
       (atomically $ fail "hello world" :: MonadConc m => m ())  -- avoid an ambiguous type

--- a/dejafu-tests/lib/Unit.hs
+++ b/dejafu-tests/lib/Unit.hs
@@ -11,14 +11,16 @@ import           Test.Tasty.Hedgehog (HedgehogDiscardLimit(..),
 import           Test.Tasty.Options  (IsOption(..), OptionDescription(..))
 import           Text.Read           (readMaybe)
 
-import qualified Unit.Properties     as P
+import qualified Unit.Predicates     as PE
+import qualified Unit.Properties     as PO
 
 import           Common
 
 -- | Run all the unit tests.
 tests :: [TestTree]
 tests = map applyHedgehogOptions
-  [ testGroup "Properties" P.tests
+  [ testGroup "Predicates" PE.tests
+  , testGroup "Properties" PO.tests
   ]
 
 -- | Tasty options

--- a/dejafu-tests/lib/Unit/Predicates.hs
+++ b/dejafu-tests/lib/Unit/Predicates.hs
@@ -1,0 +1,78 @@
+module Unit.Predicates where
+
+import qualified Test.DejaFu      as D
+import           Test.Tasty.HUnit
+
+import           Common
+
+tests :: [TestTree]
+tests =
+  [ testGroup "alwaysSameBy"     alwaysSameBy
+  , testGroup "notAlwaysSameBy"  notAlwaysSameBy
+  , testGroup "alwaysNothing"    alwaysNothing
+  , testGroup "somewhereNothing" somewhereNothing
+  , testGroup "gives"            gives
+  ]
+
+-------------------------------------------------------------------------------
+
+alwaysSameBy :: [TestTree]
+alwaysSameBy = toTestList
+  [ passes "Equal successes"   (D.alwaysSameBy (==)) [Right 1, Right 1, Right 1]
+  , fails  "Unequal successes" (D.alwaysSameBy (==)) [Right 1, Right 2, Right 3]
+  , fails  "Equal failures"    (D.alwaysSameBy (==)) [Left D.Deadlock, Left D.Deadlock, Left D.Deadlock]
+  , fails  "Unequal failures"  (D.alwaysSameBy (==)) [Left D.Deadlock, Left D.STMDeadlock, Left D.Abort]
+  , fails  "Mixed failures and successes" (D.alwaysSameBy (==)) [Left D.Deadlock, Right 1, Right 1]
+  ]
+
+-------------------------------------------------------------------------------
+
+notAlwaysSameBy :: [TestTree]
+notAlwaysSameBy = toTestList
+  [ fails  "Equal successes"   (D.notAlwaysSameBy (/=)) [Right 1, Right 1, Right 1]
+  , passes "Unequal successes" (D.notAlwaysSameBy (/=)) [Right 1, Right 2, Right 3]
+  , fails  "Equal failures"    (D.notAlwaysSameBy (/=)) [Left D.Deadlock, Left D.Deadlock, Left D.Deadlock]
+  , fails  "Unequal failures"  (D.notAlwaysSameBy (/=)) [Left D.Deadlock, Left D.STMDeadlock, Left D.Abort]
+  , fails  "Mixed failures and successes" (D.notAlwaysSameBy (/=)) [Left D.Deadlock, Right 1, Right 1]
+  ]
+
+-------------------------------------------------------------------------------
+
+alwaysNothing :: [TestTree]
+alwaysNothing = toTestList
+  [ passes "Always"    (D.alwaysNothing (const Nothing)) [Right 1, Right 2, Left D.Deadlock]
+  , fails  "Somewhere" (D.alwaysNothing (either (Just . Left) (const Nothing))) [Right 1, Right 2, Left D.Deadlock]
+  , fails  "Never"     (D.alwaysNothing Just) [Right 1, Right 2, Left D.Deadlock]
+  ]
+
+-------------------------------------------------------------------------------
+
+somewhereNothing :: [TestTree]
+somewhereNothing = toTestList
+  [ passes "Always"    (D.somewhereNothing (const Nothing)) [Right 1, Right 2, Left D.Deadlock]
+  , passes "Somewhere" (D.somewhereNothing (either (Just . Left) (const Nothing))) [Right 1, Right 2, Left D.Deadlock]
+  , fails  "Never"     (D.somewhereNothing Just) [Right 1, Right 2, Left D.Deadlock]
+  ]
+
+-------------------------------------------------------------------------------
+
+gives :: [TestTree]
+gives = toTestList
+  [ passes "Exact match"     (D.gives [Right 1, Right 2]) [Right 1, Right 2]
+  , fails  "Extra results"   (D.gives [Right 1, Right 2]) [Right 1, Right 2, Right 3]
+  , fails  "Missing results" (D.gives [Right 1, Right 2]) [Right 1]
+  ]
+
+-------------------------------------------------------------------------------
+
+-- | Check a predicate passes
+passes :: String -> D.Predicate Int -> [Either D.Failure Int] -> TestTree
+passes = checkPredicate D._pass
+
+-- | Check a predicate fails
+fails :: String -> D.Predicate Int -> [Either D.Failure Int] -> TestTree
+fails = checkPredicate (not . D._pass)
+
+-- | Check a predicate
+checkPredicate :: (D.Result Int -> Bool) -> String -> D.Predicate Int -> [Either D.Failure Int] -> TestTree
+checkPredicate f msg p = testCase msg . assertBool "" . f . D.peval p . map (\efa -> (efa, []))

--- a/dejafu-tests/lib/Unit/Predicates.hs
+++ b/dejafu-tests/lib/Unit/Predicates.hs
@@ -29,11 +29,11 @@ alwaysSameBy = toTestList
 
 notAlwaysSameBy :: [TestTree]
 notAlwaysSameBy = toTestList
-  [ fails  "Equal successes"   (D.notAlwaysSameBy (/=)) [Right 1, Right 1, Right 1]
-  , passes "Unequal successes" (D.notAlwaysSameBy (/=)) [Right 1, Right 2, Right 3]
-  , fails  "Equal failures"    (D.notAlwaysSameBy (/=)) [Left D.Deadlock, Left D.Deadlock, Left D.Deadlock]
-  , fails  "Unequal failures"  (D.notAlwaysSameBy (/=)) [Left D.Deadlock, Left D.STMDeadlock, Left D.Abort]
-  , fails  "Mixed failures and successes" (D.notAlwaysSameBy (/=)) [Left D.Deadlock, Right 1, Right 1]
+  [ fails  "Equal successes"   (D.notAlwaysSameBy (==)) [Right 1, Right 1, Right 1]
+  , passes "Unequal successes" (D.notAlwaysSameBy (==)) [Right 1, Right 2, Right 3]
+  , fails  "Equal failures"    (D.notAlwaysSameBy (==)) [Left D.Deadlock, Left D.Deadlock, Left D.Deadlock]
+  , fails  "Unequal failures"  (D.notAlwaysSameBy (==)) [Left D.Deadlock, Left D.STMDeadlock, Left D.Abort]
+  , fails  "Mixed failures and successes" (D.notAlwaysSameBy (==)) [Left D.Deadlock, Right 1, Right 1]
   ]
 
 -------------------------------------------------------------------------------

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -19,6 +19,10 @@ Added
 Changed
 ~~~~~~~
 
+* ``Test.DejaFu.autocheck`` and related functions use the
+  ``successful`` predicate, rather than looking specifically for
+  deadlocks and uncaught exceptions.
+
 * (:issue:`259`) The ``Test.DejaFu.alwaysSame``, ``alwaysSameOn``,
   ``alwaysSameBy``, and ``notAlwaysSame`` predicates fail if the
   computation under test fails.

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.10.0.0 (2018-06-17)
+---------------------
+
+* Git: :tag:`dejafu-1.10.0.0`
+* Hackage: :hackage:`dejafu-1.10.0.0`
 
 Added
 ~~~~~

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,17 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Changed
+~~~~~~~
+
+* (:issue:`259`) The ``Test.DejaFu.alwaysSame``, ``alwaysSameOn``, and
+  ``alwaysSameBy`` predicates fail if the computation under test
+  fails.
+
+
 1.9.1.0 (2018-06-10)
 --------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -10,12 +10,18 @@ standard Haskell versioning scheme.
 unreleased
 ----------
 
+Added
+~~~~~
+
+* The ``Test.DejaFu.notAlwaysSameOn`` and ``notAlwaysSameBy``
+  predicates, generalising ``notAlwaysSame``.
+
 Changed
 ~~~~~~~
 
-* (:issue:`259`) The ``Test.DejaFu.alwaysSame``, ``alwaysSameOn``, and
-  ``alwaysSameBy`` predicates fail if the computation under test
-  fails.
+* (:issue:`259`) The ``Test.DejaFu.alwaysSame``, ``alwaysSameOn``,
+  ``alwaysSameBy``, and ``notAlwaysSame`` predicates fail if the
+  computation under test fails.
 
 
 1.9.1.0 (2018-06-10)

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -26,17 +26,15 @@ let example = do
 We can test it with dejafu like so:
 
 >>> autocheck example
-[pass] Never Deadlocks
-[pass] No Exceptions
-[fail] Consistent Result
+[pass] Successful
+[fail] Deterministic
     "hello" S0----S1--S0--
 <BLANKLINE>
     "world" S0----S2--S0--
 False
 
 The 'autocheck' function takes a concurrent program to test and looks
-for some common unwanted behaviours: deadlocks, uncaught exceptions in
-the main thread, and nondeterminism.  Here we see the program is
+for concurrency errors and nondeterminism.  Here we see the program is
 nondeterministic, dejafu gives us all the distinct results it found
 and, for each, a summarised execution trace leading to that result:
 
@@ -317,13 +315,12 @@ let relaxed = do
 
 -- | Automatically test a computation.
 --
--- In particular, look for deadlocks, uncaught exceptions, and
--- multiple return values.  Returns @True@ if all tests pass
+-- In particular, concurrency errors and nondeterminism.  Returns
+-- @True@ if all tests pass
 --
 -- >>> autocheck example
--- [pass] Never Deadlocks
--- [pass] No Exceptions
--- [fail] Consistent Result
+-- [pass] Successful
+-- [fail] Deterministic
 --     "hello" S0----S1--S0--
 -- <BLANKLINE>
 --     "world" S0----S2--S0--
@@ -340,9 +337,8 @@ autocheck = autocheckWithSettings defaultSettings
 -- memory model.
 --
 -- >>> autocheckWay defaultWay defaultMemType relaxed
--- [pass] Never Deadlocks
--- [pass] No Exceptions
--- [fail] Consistent Result
+-- [pass] Successful
+-- [fail] Deterministic
 --     (False,True) S0---------S1----S0--S2----S0--
 -- <BLANKLINE>
 --     (False,False) S0---------S1--P2----S1--S0---
@@ -353,9 +349,8 @@ autocheck = autocheckWithSettings defaultSettings
 -- False
 --
 -- >>> autocheckWay defaultWay SequentialConsistency relaxed
--- [pass] Never Deadlocks
--- [pass] No Exceptions
--- [fail] Consistent Result
+-- [pass] Successful
+-- [fail] Deterministic
 --     (False,True) S0---------S1----S0--S2----S0--
 -- <BLANKLINE>
 --     (True,True) S0---------S1-P2----S1---S0---
@@ -377,9 +372,8 @@ autocheckWay way = autocheckWithSettings . fromWayAndMemType way
 -- | Variant of 'autocheck' which takes a settings record.
 --
 -- >>> autocheckWithSettings (fromWayAndMemType defaultWay defaultMemType) relaxed
--- [pass] Never Deadlocks
--- [pass] No Exceptions
--- [fail] Consistent Result
+-- [pass] Successful
+-- [fail] Deterministic
 --     (False,True) S0---------S1----S0--S2----S0--
 -- <BLANKLINE>
 --     (False,False) S0---------S1--P2----S1--S0---
@@ -390,9 +384,8 @@ autocheckWay way = autocheckWithSettings . fromWayAndMemType way
 -- False
 --
 -- >>> autocheckWithSettings (fromWayAndMemType defaultWay SequentialConsistency) relaxed
--- [pass] Never Deadlocks
--- [pass] No Exceptions
--- [fail] Consistent Result
+-- [pass] Successful
+-- [fail] Deterministic
 --     (False,True) S0---------S1----S0--S2----S0--
 -- <BLANKLINE>
 --     (True,True) S0---------S1-P2----S1---S0---
@@ -408,9 +401,8 @@ autocheckWithSettings :: (MonadConc n, MonadIO n, Eq a, Show a)
   -- ^ The computation to test.
   -> n Bool
 autocheckWithSettings settings = dejafusWithSettings settings
-  [ ("Never Deadlocks",   representative deadlocksNever)
-  , ("No Exceptions",     representative exceptionsNever)
-  , ("Consistent Result", alwaysSame) -- already representative
+  [ ("Successful", representative successful)
+  , ("Deterministic", alwaysSame) -- already representative
   ]
 
 -- | Check a predicate and print the result to stdout, return 'True'

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -862,23 +862,26 @@ alwaysSameBy f = ProPredicate
 -- | Check that a computation never fails, and gives multiple distinct
 -- successful results.
 --
--- > notAlwaysSame = notAlwaysSameBy (/=)
+-- > notAlwaysSame = notAlwaysSameBy (==)
 --
 -- @since 1.0.0.0
 notAlwaysSame :: Eq a => Predicate a
-notAlwaysSame = notAlwaysSameBy (/=)
+notAlwaysSame = notAlwaysSameBy (==)
 
 -- | Check that a computation never fails, and gives multiple distinct
 -- (according to the provided function) successful results.
 --
--- > notAlwaysSameOn = notAlwaysSameBy ((/=) `on` f)
+-- > notAlwaysSameOn = notAlwaysSameBy ((==) `on` f)
 --
 -- @since unreleased
 notAlwaysSameOn :: Eq b => (a -> b) -> Predicate a
-notAlwaysSameOn f = notAlwaysSameBy ((/=) `on` f)
+notAlwaysSameOn f = notAlwaysSameBy ((==) `on` f)
 
 -- | Check that a computation never fails, and gives multiple distinct
 -- successful results, by applying a transformation on results.
+--
+-- This inverts the condition, so (eg) @notAlwaysSameBy (==)@ will
+-- pass if there are unequal results.
 --
 -- @since unreleased
 notAlwaysSameBy :: (a -> a -> Bool) -> Predicate a
@@ -895,7 +898,7 @@ notAlwaysSameBy f = ProPredicate
               _ -> res { _failures = failures ++ _failures res, _pass = False }
     }
   where
-    (.*.) = f `on` (efromRight . fst)
+    y1 .*. y2 = not (on f (efromRight . fst) y1 y2)
 
     go [y1,y2] res
       | y1 .*. y2 = res { _pass = True }

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -830,7 +830,7 @@ exceptionsSometimes = somewhereTrue $ either isUncaughtException (const False)
 --
 -- > alwaysSame = alwaysSameBy (==)
 --
--- @since unreleased
+-- @since 1.10.0.0
 alwaysSame :: Eq a => Predicate a
 alwaysSame = alwaysSameBy (==)
 
@@ -839,14 +839,14 @@ alwaysSame = alwaysSameBy (==)
 --
 -- > alwaysSameOn = alwaysSameBy ((==) `on` f)
 --
--- @since unreleased
+-- @since 1.10.0.0
 alwaysSameOn :: Eq b => (a -> b) -> Predicate a
 alwaysSameOn f = alwaysSameBy ((==) `on` f)
 
 -- | Check that the result of a computation is always the same, using
 -- some transformation on results.
 --
--- @since unreleased
+-- @since 1.10.0.0
 alwaysSameBy :: (a -> a -> Bool) -> Predicate a
 alwaysSameBy f = ProPredicate
   { pdiscard = const Nothing
@@ -864,7 +864,7 @@ alwaysSameBy f = ProPredicate
 --
 -- > notAlwaysSame = notAlwaysSameBy (==)
 --
--- @since 1.0.0.0
+-- @since 1.10.0.0
 notAlwaysSame :: Eq a => Predicate a
 notAlwaysSame = notAlwaysSameBy (==)
 
@@ -873,7 +873,7 @@ notAlwaysSame = notAlwaysSameBy (==)
 --
 -- > notAlwaysSameOn = notAlwaysSameBy ((==) `on` f)
 --
--- @since unreleased
+-- @since 1.10.0.0
 notAlwaysSameOn :: Eq b => (a -> b) -> Predicate a
 notAlwaysSameOn f = notAlwaysSameBy ((==) `on` f)
 
@@ -883,7 +883,7 @@ notAlwaysSameOn f = notAlwaysSameBy ((==) `on` f)
 -- This inverts the condition, so (eg) @notAlwaysSameBy (==)@ will
 -- pass if there are unequal results.
 --
--- @since unreleased
+-- @since 1.10.0.0
 notAlwaysSameBy :: (a -> a -> Bool) -> Predicate a
 notAlwaysSameBy f = ProPredicate
     { pdiscard = const Nothing

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -351,6 +351,12 @@ efromList :: HasCallStack => [a] -> NonEmpty a
 efromList (x:xs) = x:|xs
 efromList _ = withFrozenCallStack $ fatal "fromList: empty list"
 
+-- | 'fromRight' but with a better error message if it fails.  Use
+-- this only where it shouldn't fail!
+efromRight :: HasCallStack => Either a b -> b
+efromRight (Right b) = b
+efromRight _ = withFrozenCallStack $ fatal "fromRight: Left"
+
 -- | 'M.adjust' but which errors if the key is not present.  Use this
 -- only where it shouldn't fail!
 eadjust :: (Ord k, Show k, HasCallStack) => (v -> v) -> k -> M.Map k v -> M.Map k v

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.9.1.0
+version:             1.10.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.9.1.0
+  tag:      dejafu-1.10.0.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,10 +27,10 @@ There are a few different packages under the Déjà Fu umbrella:
 .. csv-table::
    :header: "Package", "Version", "Summary"
 
-   ":hackage:`concurrency`",  "1.5.0.0", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.9.1.0", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "1.2.0.4", "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "1.2.0.5", "Déjà Fu support for the tasty test framework"
+   ":hackage:`concurrency`",  "1.5.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
+   ":hackage:`dejafu`",       "1.10.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "1.2.0.5",  "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "1.2.0.6",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -82,16 +82,15 @@ we'll get onto that shortly.  First, the result of testing:
 .. code-block:: none
 
   > autocheck myFunction
-  [pass] Never Deadlocks
-  [pass] No Exceptions
-  [fail] Consistent Result
+  [pass] Successful
+  [fail] Deterministic
       "hello" S0----S1--S0--
 
       "world" S0----S2--S0--
   False
 
-There are no deadlocks or uncaught exceptions, which is good; but the
-program is (as you probably spotted) nondeterministic!
+There are no concurrency errors, which is good; but the program is (as
+you probably spotted) nondeterministic!
 
 Along with each result, Déjà Fu gives us a representative execution
 trace in an abbreviated form.  ``Sn`` means that thread ``n`` started

--- a/doc/unit_testing.rst
+++ b/doc/unit_testing.rst
@@ -116,6 +116,8 @@ to it from a different thread).
   ``alwaysSameOn f``,"is like ``alwaysSame``, but transforms the results with ``f`` first"
   ``alwaysSameBy f``,"is like ``alwaysSame``, but uses ``f`` instead of ``(==)`` to compare"
   ``notAlwaysSame``,"checks that the computation is nondeterministic"
+  ``notAlwaysSameOn f``,"is like ``notAlwaysSame``, but transforms the results with ``f`` first"
+  ``notAlwaysSameBy f``,"is like ``notAlwaysSame``, but uses ``f`` instead of ``(==)`` to compare"
 
 Checking for **determinism** will also find nondeterministic failures:
 deadlocking (for instance) is still a result of a test!

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.0.5 (2018-06-17)
+--------------------
+
+* Git: :tag:`hunit-dejafu-1.2.0.5`
+* Hackage: :hackage:`hunit-dejafu-1.2.0.5`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.11.
+
+
 1.2.0.4 (2018-06-10)
 --------------------
 

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             1.2.0.4
+version:             1.2.0.5
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-1.2.0.4
+  tag:      hunit-dejafu-1.2.0.5
 
 library
   exposed-modules:     Test.HUnit.DejaFu
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.9 && <5
                      , exceptions >=0.7 && <0.11
-                     , dejafu     >=1.5 && <1.10
+                     , dejafu     >=1.5 && <1.11
                      , HUnit      >=1.3.1 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.0.6 (2018-06-17)
+--------------------
+
+* Git: :tag:`tasty-dejafu-1.2.0.6`
+* Hackage: :hackage:`tasty-dejafu-1.2.0.6`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.11.
+
+
 1.2.0.5 (2018-06-10)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             1.2.0.5
+version:             1.2.0.6
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,14 +30,14 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-1.2.0.5
+  tag:      tasty-dejafu-1.2.0.6
 
 library
   exposed-modules:     Test.Tasty.DejaFu
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.9  && <5
-                     , dejafu >=1.5  && <1.10
+                     , dejafu >=1.5  && <1.11
                      , random >=1.0  && <1.2
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.2


### PR DESCRIPTION
## Summary

Saying "yes, your test has passed - your program is totally deterministic!" when in fact the program *is* deterministic but only because it deadlocks on every execution is kind of deceptive (eg, see #257)

**To do:**

- [x] Add a test case for `alwaysSame` where the results are all (equal) successes
- [x] Add a test case for `alwaysSame` where the results are all (unequal) successes
- [x] Add a test case for `alwaysSame` where the results are all (equal) failures
- [x] Add a test case for `notAlwaysSame` where the results are all (equal) successes
- [x] Add a test case for `notAlwaysSame` where the results are all (unequal) successes
- [x] Add a test case for `notAlwaysSame` where the results are all (equal) failures

Probably the best way to handle those is to add a `Unit.Predicates` module to dejafu-tests, and cover *all* the predicates in one go. 

**Related issues:** closes #259