### PR TITLE
Add a "safe IO" flag

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.5.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.10.0.0 | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 1.10.1.0 | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 1.2.0.5  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 1.2.0.6  | Deja Fu support for the Tasty test framework. |
 

--- a/dejafu-tests/lib/Examples/ParMonad.hs
+++ b/dejafu-tests/lib/Examples/ParMonad.hs
@@ -11,7 +11,7 @@ import           Common
 
 tests :: [TestTree]
 tests = toTestList
-  [ W "random testing exposes a deadlock" parFilter deadlocksSometimes ("randomly", randomly (mkStdGen 0) 150)
+  [ TEST' True "testing exposes a deadlock" parFilter deadlocksSometimes [("randomly", toSettings (randomly (mkStdGen 0) 150)), ("systematically", defaultSettings)] True
   ]
 
 parFilter :: (MonadConc m, MonadIO m) => m Bool

--- a/dejafu-tests/lib/Integration/Litmus.hs
+++ b/dejafu-tests/lib/Integration/Litmus.hs
@@ -49,7 +49,7 @@ litmusTest name act sq tso pso = testGroup name
   [ testDejafuWithSettings (set lmemtype SequentialConsistency (toSettings defaultWay)) "SQ"  (gives' sq)  act
   , testDejafuWithSettings (set lmemtype TotalStoreOrder       (toSettings defaultWay)) "TSO" (gives' tso) act
   , testDejafuWithSettings (set lmemtype PartialStoreOrder     (toSettings defaultWay)) "PSO" (gives' pso) act
-  , H.testProperty "dependency func." (prop_dep_fun act)
+  , H.testProperty "dependency func." (prop_dep_fun False act)
   ]
 
 -- | Run a litmus test against the three different memory models, and

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -251,20 +251,22 @@ sctProps = toTestList
       H.assert (SCT.canInterruptL ds tid (D.rewind act))
 
   , testProperty "dependent ==> dependent'" $ do
+      safeIO <- H.forAll HGen.bool
       ds <- H.forAll genDepState
       tid1 <- H.forAll genThreadId
       tid2 <- H.forAll genThreadId
       ta1 <- H.forAll genThreadAction
-      ta2 <- H.forAll (HGen.filter (SCT.dependent ds tid1 ta1 tid2) genThreadAction)
-      H.assert (SCT.dependent' ds tid1 ta1 tid2 (D.rewind ta2))
+      ta2 <- H.forAll (HGen.filter (SCT.dependent safeIO ds tid1 ta1 tid2) genThreadAction)
+      H.assert (SCT.dependent' safeIO ds tid1 ta1 tid2 (D.rewind ta2))
 
   , testProperty "dependent x y == dependent y x" $ do
+      safeIO <- H.forAll HGen.bool
       ds <- H.forAll genDepState
       tid1 <- H.forAll genThreadId
       tid2 <- H.forAll genThreadId
       ta1 <- H.forAll genThreadAction
       ta2 <- H.forAll genThreadAction
-      SCT.dependent ds tid1 ta1 tid2 ta2 H.=== SCT.dependent ds tid2 ta2 tid1 ta1
+      SCT.dependent safeIO ds tid1 ta1 tid2 ta2 H.=== SCT.dependent safeIO ds tid2 ta2 tid1 ta1
 
   , testProperty "dependentActions x y == dependentActions y x" $ do
       ds <- H.forAll genDepState

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,17 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Added
+~~~~~
+
+* (:issue:`224`) The ``Test.DejaFu.Settings.lsafeIO`` option, for when
+  all lifted IO is thread-safe (such as exclusively managing
+  thread-local state).
+
+
 1.10.0.0 (2018-06-17)
 ---------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.10.1.0 (2018-06-17)
+---------------------
+
+* Git: :tag:`dejafu-1.10.1.0`
+* Hackage: :hackage:`dejafu-1.10.1.0`
 
 Added
 ~~~~~

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -45,6 +45,7 @@ data Settings n a = Settings
   , _earlyExit :: Maybe (Either Failure a -> Bool)
   , _equality :: Maybe (a -> a -> Bool)
   , _simplify  :: Bool
+  , _safeIO :: Bool
   }
 
 -- | How to explore the possible executions of a concurrent program.

--- a/dejafu/Test/DejaFu/SCT.hs
+++ b/dejafu/Test/DejaFu/SCT.hs
@@ -200,11 +200,11 @@ runSCTWithSettings settings conc = case _way settings of
 
         step run dp (prefix, conservative, sleep) = do
           (res, s, trace) <- run
-            (dporSched (_memtype settings) (cBound cb0))
+            (dporSched (_safeIO settings) (_memtype settings) (cBound cb0))
             (initialDPORSchedState sleep prefix)
 
-          let bpoints = findBacktrackSteps (_memtype settings) (cBacktrack cb0) (schedBoundKill s) (schedBPoints s) trace
-          let newDPOR = incorporateTrace (_memtype settings) conservative trace dp
+          let bpoints = findBacktrackSteps (_safeIO settings) (_memtype settings) (cBacktrack cb0) (schedBoundKill s) (schedBPoints s) trace
+          let newDPOR = incorporateTrace (_safeIO settings) (_memtype settings) conservative trace dp
 
           pure $ if schedIgnore s
                  then (force newDPOR, Nothing)

--- a/dejafu/Test/DejaFu/Settings.hs
+++ b/dejafu/Test/DejaFu/Settings.hs
@@ -429,7 +429,7 @@ lsimplify afb s = (\b -> s {_simplify = b}) <$> afb (_simplify s)
 
 -- | A lens into the safe IO flag.
 --
--- @since unreleased
+-- @since 1.10.1.0
 lsafeIO :: Lens' (Settings n a) Bool
 lsafeIO afb s = (\b -> s {_safeIO = b}) <$> afb (_safeIO s)
 

--- a/dejafu/Test/DejaFu/Settings.hs
+++ b/dejafu/Test/DejaFu/Settings.hs
@@ -188,6 +188,20 @@ module Test.DejaFu.Settings
 
   , lsimplify
 
+  -- ** Safe IO
+
+  -- | Normally, dejafu has to assume any IO action can influence any
+  -- other IO action, as there is no way to peek inside them.
+  -- However, this adds considerable overhead to systematic testing.
+  -- A perfectly legitimate use of IO is in managing thread-local
+  -- state, such as a PRNG; in this case, there is no point in
+  -- exploring interleavings of IO actions from other threads.
+  --
+  -- __Warning:__ Enabling this option is /unsound/ if your IO is not
+  -- thread safe!
+
+  , lsafeIO
+
   -- ** Debug output
 
   -- | You can opt to receive debugging messages by setting debugging
@@ -241,6 +255,7 @@ fromWayAndMemType way memtype = Settings
   , _earlyExit = Nothing
   , _equality = Nothing
   , _simplify = False
+  , _safeIO = False
   }
 
 -------------------------------------------------------------------------------
@@ -408,6 +423,15 @@ lequality afb s = (\b -> s {_equality = b}) <$> afb (_equality s)
 -- @since 1.3.2.0
 lsimplify :: Lens' (Settings n a) Bool
 lsimplify afb s = (\b -> s {_simplify = b}) <$> afb (_simplify s)
+
+-------------------------------------------------------------------------------
+-- Safe IO
+
+-- | A lens into the safe IO flag.
+--
+-- @since unreleased
+lsafeIO :: Lens' (Settings n a) Bool
+lsafeIO afb s = (\b -> s {_safeIO = b}) <$> afb (_safeIO s)
 
 -------------------------------------------------------------------------------
 -- Debug output

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.10.0.0
+version:             1.10.1.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.10.0.0
+  tag:      dejafu-1.10.1.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -38,6 +38,9 @@ The available settings are:
 * **Trace simplification**, rewriting execution traces into a simpler
   form (particularly effective with the random testing).
 
+* **Safe IO**, pruning needless schedules when your IO is only used to
+  manage thread-local state.
+
 See the ``Test.DejaFu.Settings`` module for more information.
 
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.5.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.10.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "1.10.1.0", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "1.2.0.5",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "1.2.0.6",  "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
## Summary

Adds a flag to indicate all IO is thread-safe.  This doesn't help with programs that have a mix of thread-safe and thread-unsafe IO, but I hope that there is a reasonably large class of programs where the only IO is for things like thread-local PRNGs and the like.

**Related issues:** closes #224

## Checklist

- [x] Add new tests to dejafu-tests
- [x] Performance comparison on systematic testing for par monad example

## Benchmark results

### Without systematic par test

**Before:**

```
$ stack exec -- dejafu-tests +RTS -s

 142,901,146,320 bytes allocated in the heap
  31,388,207,960 bytes copied during GC
      14,024,608 bytes maximum residency (6323 sample(s))
         146,744 bytes maximum slop
              38 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     131731 colls,     0 par   70.915s  70.897s     0.0005s    0.0354s
  Gen  1      6323 colls,     0 par    4.964s   4.963s     0.0008s    0.0022s

  TASKS: 227991 (227986 bound, 5 peak workers (5 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time  171.291s  (163.647s elapsed)
  GC      time   75.879s  ( 75.860s elapsed)
  EXIT    time    0.001s  (  0.003s elapsed)
  Total   time  247.171s  (239.510s elapsed)

  Alloc rate    834,260,065 bytes per MUT second

  Productivity  69.3% of total user, 68.3% of total elapsed
```

**After:**

```
$ stack exec -- dejafu-tests +RTS -s

 143,989,514,888 bytes allocated in the heap
  31,970,755,160 bytes copied during GC
      14,022,152 bytes maximum residency (6201 sample(s))
         145,816 bytes maximum slop
              38 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     132926 colls,     0 par   72.848s  72.780s     0.0005s    0.0330s
  Gen  1      6201 colls,     0 par    4.891s   4.888s     0.0008s    0.0024s

  TASKS: 227859 (227854 bound, 5 peak workers (5 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time  169.741s  (162.130s elapsed)
  GC      time   77.738s  ( 77.668s elapsed)
  EXIT    time    0.001s  (  0.003s elapsed)
  Total   time  247.481s  (239.800s elapsed)

  Alloc rate    848,289,519 bytes per MUT second

  Productivity  68.6% of total user, 67.6% of total elapsed
```
### With systematic par test

**Before:**

```
$ stack exec -- dejafu-tests +RTS -s

 621,082,673,912 bytes allocated in the heap                                                                                          
 319,844,942,272 bytes copied during GC
     174,860,488 bytes maximum residency (8406 sample(s))
       1,697,592 bytes maximum slop
             489 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     586924 colls,     0 par   544.721s  544.390s     0.0009s    0.2977s
  Gen  1      8406 colls,     0 par    6.108s   6.104s     0.0007s    0.0019s

  TASKS: 241379 (241374 bound, 5 peak workers (5 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time  416.744s  (408.224s elapsed)
  GC      time  550.829s  (550.494s elapsed)
  EXIT    time    0.034s  (  0.042s elapsed)
  Total   time  967.607s  (958.760s elapsed)

  Alloc rate    1,490,321,894 bytes per MUT second

  Productivity  43.1% of total user, 42.6% of total elapsed
```

`ParMonad/testing exposes a deadlock/systematically` took 717.68s.

**After:**

```
$ stack exec -- dejafu-tests +RTS -s

 149,739,906,080 bytes allocated in the heap                                                                                          
  36,054,433,992 bytes copied during GC
      14,078,072 bytes maximum residency (6604 sample(s))
         197,448 bytes maximum slop
              38 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     138048 colls,     0 par   78.591s  78.554s     0.0006s    0.0376s
  Gen  1      6604 colls,     0 par    5.159s   5.161s     0.0008s    0.0029s

  TASKS: 228163 (228158 bound, 5 peak workers (5 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time  172.307s  (164.302s elapsed)
  GC      time   83.751s  ( 83.715s elapsed)
  EXIT    time    0.001s  (  0.003s elapsed)
  Total   time  256.059s  (248.020s elapsed)

  Alloc rate    869,028,162 bytes per MUT second

  Productivity  67.3% of total user, 66.2% of total elapsed
```

`ParMonad/testing exposes a deadlock/systematically` took 11.32s.