### PR TITLE
Turn all the tests into benchmarks

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -1,0 +1,8 @@
+- package:
+  - name: dejafu-tests
+  - section:
+    - name: exe:dejafu-bench exe:dejafu-tests
+    - message:
+      - name: Module reused between components
+      - module:
+        - Util

--- a/dejafu-tests/dejafu-tests.cabal
+++ b/dejafu-tests/dejafu-tests.cabal
@@ -76,3 +76,14 @@ executable dejafu-tests
   hs-source-dirs:      exe
   default-language:    Haskell2010
   ghc-options:         -Wall -threaded -rtsopts
+
+executable dejafu-bench
+  main-is:             MainBench.hs
+  other-modules:       Util
+  build-depends:       base
+                     , criterion
+                     , dejafu-tests
+                     , tasty
+  hs-source-dirs:      exe
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded -rtsopts

--- a/dejafu-tests/dejafu-tests.cabal
+++ b/dejafu-tests/dejafu-tests.cabal
@@ -68,8 +68,8 @@ library
   ghc-options:         -Wall
 
 executable dejafu-tests
-  main-is:             Main.hs
-
+  main-is:             MainTest.hs
+  other-modules:       Util
   build-depends:       base
                      , dejafu-tests
                      , tasty

--- a/dejafu-tests/exe/MainBench.hs
+++ b/dejafu-tests/exe/MainBench.hs
@@ -1,0 +1,25 @@
+module Main where
+
+import qualified Criterion.Main       as C
+import           Data.Monoid          (mempty)
+import qualified Test.Tasty.Options   as T
+import qualified Test.Tasty.Providers as T
+import qualified Test.Tasty.Runners   as T
+
+import           Util
+
+main :: IO ()
+main = C.defaultMain (T.foldTestTree mkBench mempty tests)
+
+-- | Turn a test tree into a list of benchmarks.
+mkBench :: T.TreeFold [C.Benchmark]
+mkBench = T.trivialFold
+  { T.foldSingle = \opts lbl t -> [C.bench lbl (benchTest opts t)]
+  , T.foldGroup = \lbl bs -> [C.bgroup lbl bs]
+  }
+
+-- | Turn a test into a benchmark.
+benchTest :: T.IsTest t => T.OptionSet -> t -> C.Benchmarkable
+benchTest opts t = C.nfIO $ do
+  res <- T.run opts t (\_ -> pure ())
+  pure (show (T.resultOutcome res), T.resultTime res)

--- a/dejafu-tests/exe/MainTest.hs
+++ b/dejafu-tests/exe/MainTest.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import           Test.Tasty (defaultMainWithIngredients)
+
+import           Util
+
+main :: IO ()
+main = defaultMainWithIngredients ingredients tests

--- a/dejafu-tests/exe/Util.hs
+++ b/dejafu-tests/exe/Util.hs
@@ -1,17 +1,15 @@
-module Main where
+module Util (ingredients, tests) where
 
 import qualified Test.Tasty         as T
 import qualified Test.Tasty.Options as T
+import qualified Test.Tasty.Runners as T
 
 import qualified Examples           as E
 import qualified Integration        as I
 import qualified Unit               as U
 
-main :: IO ()
-main =
-  let ingredients = T.includingOptions options : T.defaultIngredients
-      runner = T.defaultMainWithIngredients ingredients
-  in runner tests
+ingredients :: [T.Ingredient]
+ingredients = T.includingOptions options : T.defaultIngredients
 
 tests :: T.TestTree
 tests = T.testGroup "Tests"


### PR DESCRIPTION
## Summary

This PR adds a new executable, `dejafu-bench`, which runs every test in `dejafu-tests` through [crietrion](http://hackage.haskell.org/package/criterion).

This is a nice middle-ground between having a proper collection of benchmark programs (which ideally we'll still get) and just profiling `dejafu-tests`.

**Related issues:** closes #99