### PR TITLE
Rename CRef to IORef

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,10 +45,10 @@ There are a few different packages under the Déjà Fu umbrella:
 
 |   | Version | Summary |
 | - | ------- | ------- |
-| [concurrency][h:conc]    | 1.5.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.10.1.0 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 1.2.0.5  | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 1.2.0.6  | Deja Fu support for the Tasty test framework. |
+| [concurrency][h:conc]    | 1.6.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
+| [dejafu][h:dejafu]       | 1.11.0.0 | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 1.2.0.6  | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 1.2.0.7  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -10,6 +10,12 @@ standard Haskell versioning scheme.
 unreleased - IORefs
 -------------------
 
+Added
+~~~~~
+
+* ``Control.Concurrent.Classy.CRef``, deprecated ``*CRef`` functions
+  and a ``CRef`` alias.
+
 Changed
 ~~~~~~~
 

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased - IORefs
--------------------
+1.6.0.0 - IORefs (2018-07-01)
+-----------------------------
+
+* Git: :tag:`concurrency-1.6.0.0`
+* Hackage: :hackage:`concurrency-1.6.0.0`
 
 Added
 ~~~~~

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,6 +7,16 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased - IORefs
+-------------------
+
+Changed
+~~~~~~~
+
+* (:issue:`274`) ``CRef`` is now ``IORef``: all functions, modules,
+  and types have been renamed.
+
+
 1.5.0.0 - No More 7.10 (2018-03-28)
 -----------------------------------
 

--- a/concurrency/Control/Concurrent/Classy.hs
+++ b/concurrency/Control/Concurrent/Classy.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- |
 -- Module      : Control.Concurrent.Classy
 -- Copyright   : (c) 2016 Michael Walker
@@ -22,6 +24,7 @@
 module Control.Concurrent.Classy
   ( module Control.Monad.Conc.Class
   , module Control.Concurrent.Classy.Chan
+  , module Control.Concurrent.Classy.CRef
   , module Control.Concurrent.Classy.IORef
   , module Control.Concurrent.Classy.MVar
   , module Control.Concurrent.Classy.STM
@@ -30,6 +33,7 @@ module Control.Concurrent.Classy
   ) where
 
 import           Control.Concurrent.Classy.Chan
+import           Control.Concurrent.Classy.CRef
 import           Control.Concurrent.Classy.IORef
 import           Control.Concurrent.Classy.MVar
 import           Control.Concurrent.Classy.QSem

--- a/concurrency/Control/Concurrent/Classy.hs
+++ b/concurrency/Control/Concurrent/Classy.hs
@@ -22,7 +22,7 @@
 module Control.Concurrent.Classy
   ( module Control.Monad.Conc.Class
   , module Control.Concurrent.Classy.Chan
-  , module Control.Concurrent.Classy.CRef
+  , module Control.Concurrent.Classy.IORef
   , module Control.Concurrent.Classy.MVar
   , module Control.Concurrent.Classy.STM
   , module Control.Concurrent.Classy.QSem
@@ -30,7 +30,7 @@ module Control.Concurrent.Classy
   ) where
 
 import           Control.Concurrent.Classy.Chan
-import           Control.Concurrent.Classy.CRef
+import           Control.Concurrent.Classy.IORef
 import           Control.Concurrent.Classy.MVar
 import           Control.Concurrent.Classy.QSem
 import           Control.Concurrent.Classy.QSemN

--- a/concurrency/Control/Concurrent/Classy/CRef.hs
+++ b/concurrency/Control/Concurrent/Classy/CRef.hs
@@ -1,0 +1,168 @@
+-- |
+-- Module      : Control.Concurrent.Classy.CRef
+-- Copyright   : (c) 2016--2018 Michael Walker
+-- License     : MIT
+-- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
+-- Stability   : experimental
+-- Portability : portable
+--
+-- Deprecated re-exports of @IORef@ functions under the old @CRef@
+-- names.
+module Control.Concurrent.Classy.CRef {-# DEPRECATED "Import Control.Concurrent.Classy.IORef instead" #-}
+  ( -- * CRefs
+    CRef
+  , newCRef
+  , newCRefN
+  , readCRef
+  , writeCRef
+  , modifyCRef
+  , modifyCRef'
+  , atomicModifyCRef
+  , atomicModifyCRef'
+  , atomicWriteCRef
+
+  -- ** Compare-and-swap
+  , casCRef
+  , modifyCRefCAS
+  , modifyCRefCAS_
+
+  -- * Memory Model
+
+  -- | In a concurrent program, @CRef@ operations may appear
+  -- out-of-order to another thread, depending on the memory model of
+  -- the underlying processor architecture. For example, on x86 (which
+  -- uses total store order), loads can move ahead of stores. Consider
+  -- this example:
+  --
+  -- > crefs :: MonadConc m => m (Bool, Bool)
+  -- > crefs = do
+  -- >   r1 <- newCRef False
+  -- >   r2 <- newCRef False
+  -- >
+  -- >   x <- spawn $ writeCRef r1 True >> readCRef r2
+  -- >   y <- spawn $ writeCRef r2 True >> readCRef r1
+  -- >
+  -- >   (,) <$> readMVar x <*> readMVar y
+  --
+  -- Under a sequentially consistent memory model the possible results
+  -- are @(True, True)@, @(True, False)@, and @(False, True)@. Under
+  -- total or partial store order, @(False, False)@ is also a possible
+  -- result, even though there is no interleaving of the threads which
+  -- can lead to this.
+  --
+  -- We can see this by testing with different memory models:
+  --
+  -- > > autocheckWay defaultWay SequentialConsistency relaxed
+  -- > [pass] Never Deadlocks
+  -- > [pass] No Exceptions
+  -- > [fail] Consistent Result
+  -- >        (False,True) S0---------S1----S0--S2----S0--
+  -- >
+  -- >        (True,True) S0---------S1-P2----S1---S0---
+  -- >
+  -- >        (True,False) S0---------S2----S1----S0---
+  -- > False
+  --
+  -- > > autocheckWay defaultWay TotalStoreOrder  relaxed
+  -- > [pass] Never Deadlocks
+  -- > [pass] No Exceptions
+  -- > [fail] Consistent Result
+  -- >         (False,True) S0---------S1----S0--S2----S0--
+  -- >
+  -- >         (False,False) S0---------S1--P2----S1--S0---
+  -- >
+  -- >         (True,False) S0---------S2----S1----S0---
+  -- >
+  -- >         (True,True) S0---------S1-C-S2----S1---S0---
+  -- > False
+  --
+  -- Traces for non-sequentially-consistent memory models show where
+  -- writes to @CRef@s are /committed/, which makes a write visible to
+  -- all threads rather than just the one which performed the
+  -- write. Only 'writeCRef' is broken up into separate write and
+  -- commit steps, 'atomicModifyCRef' is still atomic and imposes a
+  -- memory barrier.
+  ) where
+
+import qualified Control.Concurrent.Classy.IORef as IORef
+import           Control.Monad.Conc.Class        (IORef, MonadConc, Ticket)
+import qualified Control.Monad.Conc.Class        as IORef
+
+-- | Type alias for 'IORef'.
+type CRef m a = IORef m a
+{-# DEPRECATED CRef "Use IORef instead" #-}
+
+-- | Create a new reference.
+newCRef :: MonadConc m => a -> m (CRef m a)
+newCRef = IORef.newIORef
+{-# DEPRECATED newCRef "Use newIORef instead" #-}
+
+-- | Create a new reference, but it is given a name which may be used
+-- to present more useful debugging information.
+newCRefN :: MonadConc m => String -> a -> m (CRef m a)
+newCRefN = IORef.newIORefN
+{-# DEPRECATED newCRefN "Use newIORefN instead" #-}
+
+-- | Read the current value stored in a reference.
+readCRef :: MonadConc m => CRef m a -> m a
+readCRef = IORef.readIORef
+{-# DEPRECATED readCRef "Use readIORef instead" #-}
+
+-- | Write a new value into an @CRef@, without imposing a memory
+-- barrier. This means that relaxed memory effects can be observed.
+writeCRef :: MonadConc m => CRef m a -> a -> m ()
+writeCRef = IORef.writeIORef
+{-# DEPRECATED writeCRef "Use writeIORef instead" #-}
+
+-- | Mutate the contents of a @CRef@.
+--
+-- Be warned that 'modifyCRef' does not apply the function strictly.
+-- This means if the program calls 'modifyCRef' many times, but
+-- seldomly uses the value, thunks will pile up in memory resulting in
+-- a space leak.
+modifyCRef :: MonadConc m => CRef m a -> (a -> a) -> m ()
+modifyCRef = IORef.modifyIORef
+{-# DEPRECATED modifyCRef "Use modifyIORef instead" #-}
+
+-- | Strict version of 'modifyCRef'
+modifyCRef' :: MonadConc m => CRef m a -> (a -> a) -> m ()
+modifyCRef' = IORef.modifyIORef'
+{-# DEPRECATED modifyCRef' "Use modifyIORef' instead" #-}
+
+-- | Atomically modify the value stored in a reference. This imposes
+-- a full memory barrier.
+atomicModifyCRef :: MonadConc m => CRef m a -> (a -> (a, b)) -> m b
+atomicModifyCRef = IORef.atomicModifyIORef
+{-# DEPRECATED atomicModifyCRef "Use atomicModifyIORef instead" #-}
+
+-- | Strict version of 'atomicModifyCRef'. This forces both the value
+-- stored in the @CRef@ as well as the value returned.
+atomicModifyCRef' :: MonadConc m => CRef m a -> (a -> (a,b)) -> m b
+atomicModifyCRef' = IORef.atomicModifyIORef'
+{-# DEPRECATED atomicModifyCRef' "Use atomicModifyIORef' instead" #-}
+
+-- | Replace the value stored in a reference, with the
+-- barrier-to-reordering property that 'atomicModifyIORef' has.
+atomicWriteCRef :: MonadConc m => CRef m a -> a -> m ()
+atomicWriteCRef = IORef.atomicWriteIORef
+{-# DEPRECATED atomicWriteCRef "Use atomicWriteIORef instead" #-}
+
+-- | Perform a machine-level compare-and-swap (CAS) operation on a
+-- @CRef@. Returns an indication of success and a @Ticket@ for the
+-- most current value in the @CRef@.
+-- This is strict in the \"new\" value argument.
+casCRef :: MonadConc m => CRef m a -> Ticket m a -> a -> m (Bool, Ticket m a)
+casCRef = IORef.casIORef
+{-# DEPRECATED casCRef "Use casIORef instead" #-}
+
+-- | A replacement for 'atomicModifyCRef' using a compare-and-swap.
+--
+-- This is strict in the \"new\" value argument.
+modifyCRefCAS :: MonadConc m => CRef m a -> (a -> (a, b)) -> m b
+modifyCRefCAS = IORef.modifyIORefCAS
+{-# DEPRECATED modifyCRefCAS "Use modifyIORefCAS instead" #-}
+
+-- | A variant of 'modifyCRefCAS' which doesn't return a result.
+modifyCRefCAS_ :: MonadConc m => CRef m a -> (a -> a) -> m ()
+modifyCRefCAS_ = IORef.modifyIORefCAS_
+{-# DEPRECATED modifyCRefCAS_ "Use modifyIORefCAS_ instead" #-}

--- a/concurrency/Control/Concurrent/Classy/IORef.hs
+++ b/concurrency/Control/Concurrent/Classy/IORef.hs
@@ -97,13 +97,13 @@ import           Control.Monad.Conc.Class
 --
 -- To avoid this problem, use 'modifyIORef'' instead.
 --
--- @since unreleased
+-- @since 1.6.0.0
 modifyIORef :: MonadConc m => IORef m a -> (a -> a) -> m ()
 modifyIORef ref f = readIORef ref >>= writeIORef ref . f
 
 -- | Strict version of 'modifyIORef'
 --
--- @since unreleased
+-- @since 1.6.0.0
 modifyIORef' :: MonadConc m => IORef m a -> (a -> a) -> m ()
 modifyIORef' ref f = do
   x <- readIORef ref
@@ -112,7 +112,7 @@ modifyIORef' ref f = do
 -- | Strict version of 'atomicModifyIORef'. This forces both the value
 -- stored in the @IORef@ as well as the value returned.
 --
--- @since unreleased
+-- @since 1.6.0.0
 atomicModifyIORef' :: MonadConc m => IORef m a -> (a -> (a,b)) -> m b
 atomicModifyIORef' ref f = do
   b <- atomicModifyIORef ref $ \a -> case f a of

--- a/concurrency/Control/Concurrent/Classy/IORef.hs
+++ b/concurrency/Control/Concurrent/Classy/IORef.hs
@@ -1,6 +1,6 @@
 -- |
--- Module      : Control.Concurrent.Classy.CRef
--- Copyright   : (c) 2016 Michael Walker
+-- Module      : Control.Concurrent.Classy.IORef
+-- Copyright   : (c) 2018 Michael Walker
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : stable
@@ -9,34 +9,34 @@
 -- Mutable references in a concurrency monad.
 --
 -- __Deviations:__ There is no @Eq@ instance for @MonadConc@ the
--- @CRef@ type. Furthermore, the @mkWeakIORef@ function is not
+-- @IORef@ type. Furthermore, the @mkWeakIORef@ function is not
 -- provided.
-module Control.Concurrent.Classy.CRef
-  ( -- * CRefs
-    newCRef
-  , readCRef
-  , writeCRef
-  , modifyCRef
-  , modifyCRef'
-  , atomicModifyCRef
-  , atomicModifyCRef'
-  , atomicWriteCRef
+module Control.Concurrent.Classy.IORef
+  ( -- * IORefs
+    newIORef
+  , readIORef
+  , writeIORef
+  , modifyIORef
+  , modifyIORef'
+  , atomicModifyIORef
+  , atomicModifyIORef'
+  , atomicWriteIORef
 
   -- * Memory Model
 
-  -- | In a concurrent program, @CRef@ operations may appear
+  -- | In a concurrent program, @IORef@ operations may appear
   -- out-of-order to another thread, depending on the memory model of
   -- the underlying processor architecture. For example, on x86 (which
   -- uses total store order), loads can move ahead of stores. Consider
   -- this example:
   --
-  -- > crefs :: MonadConc m => m (Bool, Bool)
-  -- > crefs = do
-  -- >   r1 <- newCRef False
-  -- >   r2 <- newCRef False
+  -- > iorefs :: MonadConc m => m (Bool, Bool)
+  -- > iorefs = do
+  -- >   r1 <- newIORef False
+  -- >   r2 <- newIORef False
   -- >
-  -- >   x <- spawn $ writeCRef r1 True >> readCRef r2
-  -- >   y <- spawn $ writeCRef r2 True >> readCRef r1
+  -- >   x <- spawn $ writeIORef r1 True >> readIORef r2
+  -- >   y <- spawn $ writeIORef r2 True >> readIORef r1
   -- >
   -- >   (,) <$> readMVar x <*> readMVar y
   --
@@ -73,48 +73,48 @@ module Control.Concurrent.Classy.CRef
   -- > False
   --
   -- Traces for non-sequentially-consistent memory models show where
-  -- writes to @CRef@s are /committed/, which makes a write visible to
+  -- writes to @IORef@s are /committed/, which makes a write visible to
   -- all threads rather than just the one which performed the
-  -- write. Only 'writeCRef' is broken up into separate write and
-  -- commit steps, 'atomicModifyCRef' is still atomic and imposes a
+  -- write. Only 'writeIORef' is broken up into separate write and
+  -- commit steps, 'atomicModifyIORef' is still atomic and imposes a
   -- memory barrier.
   ) where
 
 import           Control.Monad.Conc.Class
 
--- | Mutate the contents of a @CRef@.
+-- | Mutate the contents of a @IORef@.
 --
--- Be warned that 'modifyCRef' does not apply the function strictly.
--- This means if the program calls 'modifyCRef' many times, but
+-- Be warned that 'modifyIORef' does not apply the function strictly.
+-- This means if the program calls 'modifyIORef' many times, but
 -- seldomly uses the value, thunks will pile up in memory resulting in
--- a space leak. This is a common mistake made when using a @CRef@ as
+-- a space leak. This is a common mistake made when using a @IORef@ as
 -- a counter. For example, the following will likely produce a stack
 -- overflow:
 --
--- >ref <- newCRef 0
--- >replicateM_ 1000000 $ modifyCRef ref (+1)
--- >readCRef ref >>= print
+-- >ref <- newIORef 0
+-- >replicateM_ 1000000 $ modifyIORef ref (+1)
+-- >readIORef ref >>= print
 --
--- To avoid this problem, use 'modifyCRef'' instead.
+-- To avoid this problem, use 'modifyIORef'' instead.
 --
--- @since 1.0.0.0
-modifyCRef :: MonadConc m => CRef m a -> (a -> a) -> m ()
-modifyCRef ref f = readCRef ref >>= writeCRef ref . f
+-- @since unreleased
+modifyIORef :: MonadConc m => IORef m a -> (a -> a) -> m ()
+modifyIORef ref f = readIORef ref >>= writeIORef ref . f
 
--- | Strict version of 'modifyCRef'
+-- | Strict version of 'modifyIORef'
 --
--- @since 1.0.0.0
-modifyCRef' :: MonadConc m => CRef m a -> (a -> a) -> m ()
-modifyCRef' ref f = do
-  x <- readCRef ref
-  writeCRef ref $! f x
+-- @since unreleased
+modifyIORef' :: MonadConc m => IORef m a -> (a -> a) -> m ()
+modifyIORef' ref f = do
+  x <- readIORef ref
+  writeIORef ref $! f x
 
--- | Strict version of 'atomicModifyCRef'. This forces both the value
--- stored in the @CRef@ as well as the value returned.
+-- | Strict version of 'atomicModifyIORef'. This forces both the value
+-- stored in the @IORef@ as well as the value returned.
 --
--- @since 1.0.0.0
-atomicModifyCRef' :: MonadConc m => CRef m a -> (a -> (a,b)) -> m b
-atomicModifyCRef' ref f = do
-  b <- atomicModifyCRef ref $ \a -> case f a of
+-- @since unreleased
+atomicModifyIORef' :: MonadConc m => IORef m a -> (a -> (a,b)) -> m b
+atomicModifyIORef' ref f = do
+  b <- atomicModifyIORef ref $ \a -> case f a of
     v@(a',_) -> a' `seq` v
   pure $! b

--- a/concurrency/Control/Monad/Conc/Class.hs
+++ b/concurrency/Control/Monad/Conc/Class.hs
@@ -150,7 +150,7 @@ import qualified Control.Monad.Writer.Strict  as WS
 -- Do not be put off by the use of @UndecidableInstances@, it is safe
 -- here.
 --
--- @since unreleased
+-- @since 1.6.0.0
 class ( Monad m
       , MonadCatch m, MonadThrow m, MonadMask m
       , MonadSTM (STM m)
@@ -200,7 +200,7 @@ class ( Monad m
   -- relaxed memory effects if functions outside the set @newIORef@,
   -- @readIORef@, @atomicModifyIORef@, and @atomicWriteIORef@ are used.
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   type IORef m :: * -> *
 
   -- | When performing compare-and-swap operations on @IORef@s, a
@@ -378,7 +378,7 @@ class ( Monad m
   --
   -- > newIORef = newIORefN ""
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   newIORef :: a -> m (IORef m a)
   newIORef = newIORefN ""
 
@@ -387,7 +387,7 @@ class ( Monad m
   --
   -- > newIORefN _ = newIORef
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   newIORefN :: String -> a -> m (IORef m a)
   newIORefN _ = newIORef
 
@@ -395,20 +395,20 @@ class ( Monad m
   --
   -- > readIORef ioref = readForCAS ioref >>= peekTicket
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   readIORef :: IORef m a -> m a
   readIORef ioref = readForCAS ioref >>= peekTicket
 
   -- | Atomically modify the value stored in a reference. This imposes
   -- a full memory barrier.
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   atomicModifyIORef :: IORef m a -> (a -> (a, b)) -> m b
 
   -- | Write a new value into an @IORef@, without imposing a memory
   -- barrier. This means that relaxed memory effects can be observed.
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   writeIORef :: IORef m a -> a -> m ()
 
   -- | Replace the value stored in a reference, with the
@@ -416,14 +416,14 @@ class ( Monad m
   --
   -- > atomicWriteIORef r a = atomicModifyIORef r $ const (a, ())
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   atomicWriteIORef :: IORef m a -> a -> m ()
   atomicWriteIORef r a = atomicModifyIORef r $ const (a, ())
 
   -- | Read the current value stored in a reference, returning a
   -- @Ticket@, for use in future compare-and-swap operations.
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   readForCAS :: IORef m a -> m (Ticket m a)
 
   -- | Extract the actual Haskell value from a @Ticket@.
@@ -439,21 +439,21 @@ class ( Monad m
   --
   -- This is strict in the \"new\" value argument.
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   casIORef :: IORef m a -> Ticket m a -> a -> m (Bool, Ticket m a)
 
   -- | A replacement for 'atomicModifyIORef' using a compare-and-swap.
   --
   -- This is strict in the \"new\" value argument.
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   modifyIORefCAS :: IORef m a -> (a -> (a, b)) -> m b
 
   -- | A variant of 'modifyIORefCAS' which doesn't return a result.
   --
   -- > modifyIORefCAS_ ioref f = modifyIORefCAS ioref (\a -> (f a, ()))
   --
-  -- @since unreleased
+  -- @since 1.6.0.0
   modifyIORefCAS_ :: IORef m a -> (a -> a) -> m ()
   modifyIORefCAS_ ioref f = modifyIORefCAS ioref (\a -> (f a, ()))
 
@@ -690,7 +690,7 @@ peekTicket t = pure $ peekTicket' (Proxy :: Proxy m) (t :: Ticket m a)
 -- | Compare-and-swap a value in a @IORef@, returning an indication of
 -- success and the new value.
 --
--- @since unreleased
+-- @since 1.6.0.0
 cas :: MonadConc m => IORef m a -> a -> m (Bool, a)
 cas ioref a = do
   tick         <- readForCAS ioref

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -41,6 +41,7 @@ library
                      , Control.Concurrent.Classy
                      , Control.Concurrent.Classy.Async
                      , Control.Concurrent.Classy.Chan
+                     , Control.Concurrent.Classy.CRef
                      , Control.Concurrent.Classy.IORef
                      , Control.Concurrent.Classy.MVar
                      , Control.Concurrent.Classy.QSem

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                concurrency
-version:             1.5.0.0
+version:             1.6.0.0
 synopsis:            Typeclasses, functions, and data types for concurrency and STM.
 
 description:
@@ -32,7 +32,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      concurrency-1.5.0.0
+  tag:      concurrency-1.6.0.0
 
 library
   exposed-modules:     Control.Monad.Conc.Class

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -41,7 +41,7 @@ library
                      , Control.Concurrent.Classy
                      , Control.Concurrent.Classy.Async
                      , Control.Concurrent.Classy.Chan
-                     , Control.Concurrent.Classy.CRef
+                     , Control.Concurrent.Classy.IORef
                      , Control.Concurrent.Classy.MVar
                      , Control.Concurrent.Classy.QSem
                      , Control.Concurrent.Classy.QSemN

--- a/dejafu-tests/lib/Common.hs
+++ b/dejafu-tests/lib/Common.hs
@@ -213,9 +213,9 @@ newEmptyMVarInt = newEmptyMVar
 newMVarInt :: MonadConc m => Int -> m (MVar m Int)
 newMVarInt = newMVar
 
--- | Create a monomorphic @CRef@.
-newCRefInt :: MonadConc m => Int -> m (CRef m Int)
-newCRefInt = newCRef
+-- | Create a monomorphic @IORef@.
+newIORefInt :: MonadConc m => Int -> m (IORef m Int)
+newIORefInt = newIORef
 
 -- | Create a monomorphic @TVar@.
 newTVarInt :: MonadSTM stm => Int -> stm (TVar stm Int)

--- a/dejafu-tests/lib/Examples/ParMonad/DirectInternal.hs
+++ b/dejafu-tests/lib/Examples/ParMonad/DirectInternal.hs
@@ -132,12 +132,12 @@ writeHotVarRaw :: MonadConc m => HotVar m a -> a -> m ()
 {-# INLINE readHotVar    #-}
 {-# INLINE writeHotVar   #-}
 
-type HotVar m a = CRef m a
-newHotVar     = newCRef
-modifyHotVar  = atomicModifyCRef
-modifyHotVar_ v fn = atomicModifyCRef v (\a -> (fn a, ()))
-readHotVar    = readCRef
-writeHotVar   = writeCRef
+type HotVar m a = IORef m a
+newHotVar     = newIORef
+modifyHotVar  = atomicModifyIORef
+modifyHotVar_ v fn = atomicModifyIORef v (\a -> (fn a, ()))
+readHotVar    = readIORef
+writeHotVar   = writeIORef
 
 readHotVarRaw  = readHotVar
 writeHotVarRaw = writeHotVar

--- a/dejafu-tests/lib/Integration/Async.hs
+++ b/dejafu-tests/lib/Integration/Async.hs
@@ -4,7 +4,7 @@
 module Integration.Async where
 
 import           Control.Concurrent.Classy.Async
-import           Control.Concurrent.Classy.CRef
+import           Control.Concurrent.Classy.IORef
 import           Control.Exception               (AsyncException(..), Exception,
                                                   SomeException, fromException)
 import           Control.Monad                   (when)
@@ -132,28 +132,28 @@ async_poll2 = do
 
 case_concurrently_ :: MonadConc m => m ()
 case_concurrently_ = do
-  ref <- newCRefInt 0
+  ref <- newIORefInt 0
   () <- concurrently_
-    (atomicModifyCRef ref (\x -> (x + 1, True)))
-    (atomicModifyCRef ref (\x -> (x + 2, 'x')))
-  res <- readCRef ref
+    (atomicModifyIORef ref (\x -> (x + 1, True)))
+    (atomicModifyIORef ref (\x -> (x + 2, 'x')))
+  res <- readIORef ref
   res @?= 3
 
 case_replicateConcurrently :: MonadConc m => m ()
 case_replicateConcurrently = do
-  ref <- newCRefInt 0
-  let action = atomicModifyCRef ref (\x -> (x + 1, x + 1))
+  ref <- newIORefInt 0
+  let action = atomicModifyIORef ref (\x -> (x + 1, x + 1))
   resList <- replicateConcurrently 4 action
-  resVal <- readCRef ref
+  resVal <- readIORef ref
   resVal @?= 4
   sort resList @?= [1..4]
 
 case_replicateConcurrently_ :: MonadConc m => m ()
 case_replicateConcurrently_ = do
-  ref <- newCRefInt 0
-  let action = atomicModifyCRef ref (\x -> (x + 1, x + 1))
+  ref <- newIORefInt 0
+  let action = atomicModifyIORef ref (\x -> (x + 1, x + 1))
   () <- replicateConcurrently_ 4 action
-  resVal <- readCRef ref
+  resVal <- readIORef ref
   resVal @?= 4
 
 -------------------------------------------------------------------------------

--- a/dejafu-tests/lib/Integration/Names.hs
+++ b/dejafu-tests/lib/Integration/Names.hs
@@ -3,7 +3,7 @@ module Integration.Names where
 import           Control.Concurrent.Classy hiding (check)
 import           Data.Maybe                (mapMaybe)
 import           Test.DejaFu.Conc          (ConcIO)
-import           Test.DejaFu.Internal      (crefOf, mvarOf, simplifyAction,
+import           Test.DejaFu.Internal      (iorefOf, mvarOf, simplifyAction,
                                             tidsOf, tvarsOf)
 import           Test.DejaFu.SCT           (runSCT)
 import           Test.DejaFu.Types
@@ -15,7 +15,7 @@ tests :: [TestTree]
 tests =
   toTestList
     [ testCase "MVar names" testMVarNames
-    , testCase "CRef names" testCRefNames
+    , testCase "IORef names" testIORefNames
     , testCase "TVar names" testTVarNames
     , testCase "Thread names" testThreadNames
     ]
@@ -52,24 +52,24 @@ testMVarNames =
       let validMVid = maybe False (`elem` [mvarName1, mvarName2]) . mvarName
       in all validMVid . mapMaybe mvar
 
-testCRefNames :: Assertion
-testCRefNames =
-  check "All traces should use only required CRef names" checkCRefs $ do
-    x <- newCRefN crefName1 (0::Int)
-    y <- newCRefN crefName2 (0::Int)
-    _ <- fork $ modifyCRefCAS x (const (1, ()))
-    _ <- fork $ writeCRef y 2
-    (,) <$> readCRef x <*> readCRef y
+testIORefNames :: Assertion
+testIORefNames =
+  check "All traces should use only required IORef names" checkIORefs $ do
+    x <- newIORefN iorefName1 (0::Int)
+    y <- newIORefN iorefName2 (0::Int)
+    _ <- fork $ modifyIORefCAS x (const (1, ()))
+    _ <- fork $ writeIORef y 2
+    (,) <$> readIORef x <*> readIORef y
   where
-    crefName1 = "cref-one"
-    crefName2 = "cref-two"
-    crefName (CRefId (Id (Just n) _)) = Just n
-    crefName _ = Nothing
-    cref (NewCRef ref) = Just ref
-    cref a = crefOf (simplifyAction a)
-    checkCRefs =
-      let validCRef = maybe False (`elem` [crefName1, crefName2]) . crefName
-      in all validCRef . mapMaybe cref
+    iorefName1 = "ioref-one"
+    iorefName2 = "ioref-two"
+    iorefName (IORefId (Id (Just n) _)) = Just n
+    iorefName _ = Nothing
+    ioref (NewIORef ref) = Just ref
+    ioref a = iorefOf (simplifyAction a)
+    checkIORefs =
+      let validIORef = maybe False (`elem` [iorefName1, iorefName2]) . iorefName
+      in all validIORef . mapMaybe ioref
 
 testTVarNames :: Assertion
 testTVarNames =

--- a/dejafu-tests/lib/Integration/Regressions.hs
+++ b/dejafu-tests/lib/Integration/Regressions.hs
@@ -16,9 +16,9 @@ import           QSemN
 tests :: [TestTree]
 tests = toTestList
   [ djfu "https://github.com/barrucadu/dejafu/issues/40" (gives' [0,1]) $ do
-      x <- newCRefInt 0
-      _ <- fork $ myThreadId >> writeCRef x 1
-      readCRef x
+      x <- newIORefInt 0
+      _ <- fork $ myThreadId >> writeIORef x 1
+      readIORef x
 
   , djfu "https://github.com/barrucadu/dejafu/issues/55" (gives' [True]) $ do
       a <- atomically newTQueue

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,16 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased - IORefs
+-------------------
+
+Changed
+~~~~~~~
+
+* (:issue:`274`) ``CRef`` is now ``IORef``: all functions, data
+  constructors, and types have been renamed.
+
+
 1.10.1.0 (2018-06-17)
 ---------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,14 +7,19 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased - IORefs
--------------------
+1.11.0.0 - IORefs (2018-07-01)
+------------------------------
+
+* Git: :tag:`dejafu-1.11.0.0`
+* Hackage: :hackage:`dejafu-1.11.0.0`
 
 Changed
 ~~~~~~~
 
 * (:issue:`274`) ``CRef`` is now ``IORef``: all functions, data
   constructors, and types have been renamed.
+
+* The lower bound on :hackage:`concurrency` is 1.6.
 
 
 1.10.1.0 (2018-06-17)

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -102,7 +102,7 @@ There are a few knobs to tweak to control the behaviour of dejafu.
 The defaults should generally be good enough, but if not you have a
 few tricks available.  The main two are: the 'Way', which controls how
 schedules are explored; and the 'MemType', which controls how reads
-and writes to @CRef@s behave; see "Test.DejaFu.Settings" for a
+and writes to @IORef@s behave; see "Test.DejaFu.Settings" for a
 complete listing.
 
 -}
@@ -301,10 +301,10 @@ let example = do
 
 >>> :{
 let relaxed = do
-      r1 <- newCRef False
-      r2 <- newCRef False
-      x <- spawn $ writeCRef r1 True >> readCRef r2
-      y <- spawn $ writeCRef r2 True >> readCRef r1
+      r1 <- newIORef False
+      r2 <- newIORef False
+      x <- spawn $ writeIORef r1 True >> readIORef r2
+      y <- spawn $ writeIORef r2 True >> readIORef r1
       (,) <$> readMVar x <*> readMVar y
 :}
 
@@ -363,7 +363,7 @@ autocheckWay :: (MonadConc n, MonadIO n, Eq a, Show a)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> ConcT n a
   -- ^ The computation to test.
   -> n Bool
@@ -454,7 +454,7 @@ dejafuWay :: (MonadConc n, MonadIO n, Show b)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
@@ -505,7 +505,7 @@ dejafuDiscard :: (MonadConc n, MonadIO n, Show b)
   -> Way
   -- ^ How to run the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
@@ -555,7 +555,7 @@ dejafusWay :: (MonadConc n, MonadIO n, Show b)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
   -> ConcT n a
@@ -672,7 +672,7 @@ runTestWay :: MonadConc n
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> ProPredicate a b
   -- ^ The predicate to check
   -> ConcT n a

--- a/dejafu/Test/DejaFu/SCT.hs
+++ b/dejafu/Test/DejaFu/SCT.hs
@@ -69,7 +69,7 @@ runSCT :: MonadConc n
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
@@ -82,7 +82,7 @@ resultsSet :: (MonadConc n, Ord a)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> ConcT n a
   -- ^ The computation to run many times.
   -> n (Set (Either Failure a))
@@ -100,7 +100,7 @@ runSCTDiscard :: MonadConc n
   -> Way
   -- ^ How to run the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> ConcT n a
   -- ^ The computation to run many times.
   -> n [(Either Failure a, Trace)]
@@ -116,7 +116,7 @@ resultsSetDiscard :: (MonadConc n, Ord a)
   -> Way
   -- ^ How to run the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> ConcT n a
   -- ^ The computation to run many times.
   -> n (Set (Either Failure a))
@@ -373,7 +373,7 @@ lBacktrack = backtrackAt (\_ _ -> False)
 -- @since 1.0.0.0
 sctBound :: MonadConc n
   => MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> Bounds
   -- ^ The combined bounds.
   -> ConcT n a
@@ -392,7 +392,7 @@ sctBoundDiscard :: MonadConc n
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> Bounds
   -- ^ The combined bounds.
   -> ConcT n a
@@ -412,7 +412,7 @@ sctBoundDiscard discard memtype cb = runSCTWithSettings $
 -- @since 1.0.0.0
 sctUniformRandom :: (MonadConc n, RandomGen g)
   => MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> g
   -- ^ The random number generator.
   -> Int
@@ -433,7 +433,7 @@ sctUniformRandomDiscard :: (MonadConc n, RandomGen g)
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> g
   -- ^ The random number generator.
   -> Int
@@ -455,7 +455,7 @@ sctUniformRandomDiscard discard memtype g lim = runSCTWithSettings $
 -- @since 1.7.0.0
 sctWeightedRandom :: (MonadConc n, RandomGen g)
   => MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> g
   -- ^ The random number generator.
   -> Int
@@ -476,7 +476,7 @@ sctWeightedRandomDiscard :: (MonadConc n, RandomGen g)
   => (Either Failure a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> g
   -- ^ The random number generator.
   -> Int
@@ -533,7 +533,7 @@ yieldCountInc sofar prior (d, lnext) = case prior of
 
 -- | Determine if an action is a commit or not.
 isCommitRef :: ThreadAction -> Bool
-isCommitRef (CommitCRef _ _) = True
+isCommitRef (CommitIORef _ _) = True
 isCommitRef _ = False
 
 -- | Get the maximum difference between two ints in a list.

--- a/dejafu/Test/DejaFu/Settings.hs
+++ b/dejafu/Test/DejaFu/Settings.hs
@@ -59,22 +59,22 @@ module Test.DejaFu.Settings
 
   -- ** The @MemType@
 
-  -- | When executed on a multi-core processor some @CRef@ / @IORef@
+  -- | When executed on a multi-core processor some @IORef@ / @IORef@
   -- programs can exhibit \"relaxed memory\" behaviours, where the
   -- apparent behaviour of the program is not a simple interleaving of
   -- the actions of each thread.
   --
-  -- __Example:__ This is a simple program which creates two @CRef@s
+  -- __Example:__ This is a simple program which creates two @IORef@s
   -- containing @False@, and forks two threads.  Each thread writes
-  -- @True@ to one of the @CRef@s and reads the other.  The value that
+  -- @True@ to one of the @IORef@s and reads the other.  The value that
   -- each thread reads is communicated back through an @MVar@:
   --
   -- > >>> :{
   -- > let relaxed = do
-  -- >       r1 <- newCRef False
-  -- >       r2 <- newCRef False
-  -- >       x <- spawn $ writeCRef r1 True >> readCRef r2
-  -- >       y <- spawn $ writeCRef r2 True >> readCRef r1
+  -- >       r1 <- newIORef False
+  -- >       r2 <- newIORef False
+  -- >       x <- spawn $ writeIORef r1 True >> readIORef r2
+  -- >       y <- spawn $ writeIORef r2 True >> readIORef r1
   -- >       (,) <$> readMVar x <*> readMVar y
   -- > :}
   --
@@ -94,12 +94,12 @@ module Test.DejaFu.Settings
   -- > False
   --
   -- It's possible for both threads to read the value @False@, even
-  -- though each writes @True@ to the other @CRef@ before reading.
+  -- though each writes @True@ to the other @IORef@ before reading.
   -- This is because processors are free to re-order reads and writes
   -- to independent memory addresses in the name of performance.
   --
   -- Execution traces for relaxed memory computations can include
-  -- \"C\" actions, as above, which show where @CRef@ writes were
+  -- \"C\" actions, as above, which show where @IORef@ writes were
   -- explicitly /committed/, and made visible to other threads.
   --
   -- However, modelling this behaviour can require more executions.

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -41,7 +41,7 @@ deriving instance Generic ThreadId
 
 -- | Every @IORef@ has a unique identifier.
 --
--- @since unreleased
+-- @since 1.11.0.0
 newtype IORefId = IORefId Id
   deriving (Eq, Ord, NFData, Generic)
 
@@ -106,7 +106,7 @@ initialThread = ThreadId (Id (Just "main") 0)
 
 -- | All the actions that a thread can perform.
 --
--- @since unreleased
+-- @since 1.11.0.0
 data ThreadAction =
     Fork ThreadId
   -- ^ Start a new thread.
@@ -248,7 +248,7 @@ instance NFData ThreadAction where
 
 -- | A one-step look-ahead at what a thread will do next.
 --
--- @since unreleased
+-- @since 1.11.0.0
 data Lookahead =
     WillFork
   -- ^ Will start a new thread.

--- a/dejafu/Test/DejaFu/Utils.hs
+++ b/dejafu/Test/DejaFu/Utils.hs
@@ -34,7 +34,7 @@ toTIdTrace =
 showTrace :: Trace -> String
 showTrace []  = "<trace discarded>"
 showTrace trc = intercalate "\n" $ go False trc : strkey where
-  go _ ((_,_,CommitCRef _ _):rest) = "C-" ++ go False rest
+  go _ ((_,_,CommitIORef _ _):rest) = "C-" ++ go False rest
   go _ ((Start    (ThreadId (Id _ i)),_,a):rest) = "S" ++ show i ++ "-" ++ go (didYield a) rest
   go y ((SwitchTo (ThreadId (Id _ i)),_,a):rest) = (if y then "p" else "P") ++ show i ++ "-" ++ go (didYield a) rest
   go _ ((Continue,_,a):rest) = '-' : go (didYield a) rest
@@ -63,7 +63,7 @@ simplestsBy f = map choose . collect where
   choose  = minimumBy . comparing $ \(_, trc) ->
     let switchTos = length . filter (\(d,_,_) -> case d of SwitchTo _ -> True; _ -> False)
         starts    = length . filter (\(d,_,_) -> case d of Start    _ -> True; _ -> False)
-        commits   = length . filter (\(_,_,a) -> case a of CommitCRef _ _ -> True; _ -> False)
+        commits   = length . filter (\(_,_,a) -> case a of CommitIORef _ _ -> True; _ -> False)
     in (switchTos trc, commits trc, length trc, starts trc)
 
   groupBy' res _ [] = res

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.10.1.0
+version:             1.11.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.10.1.0
+  tag:      dejafu-1.11.0.0
 
 library
   exposed-modules:     Test.DejaFu
@@ -58,7 +58,7 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base              >=4.9 && <5
-                     , concurrency       >=1.5 && <1.6
+                     , concurrency       >=1.6 && <1.7
                      , containers        >=0.5 && <0.6
                      , contravariant     >=1.2 && <1.5
                      , deepseq           >=1.1 && <2

--- a/doc/adding_a_new_primitive.rst
+++ b/doc/adding_a_new_primitive.rst
@@ -76,23 +76,23 @@ These types live in ``Test.DejaFu.Types``:
     -- ^ Get blocked on a take.
     | TryTakeMVar MVarId Bool [ThreadId]
     -- ^ Try to take from a 'MVar', possibly waking up some threads.
-    | NewCRef CRefId
-    -- ^ Create a new 'CRef'.
-    | ReadCRef CRefId
-    -- ^ Read from a 'CRef'.
-    | ReadCRefCas CRefId
-    -- ^ Read from a 'CRef' for a future compare-and-swap.
-    | ModCRef CRefId
-    -- ^ Modify a 'CRef'.
-    | ModCRefCas CRefId
-    -- ^ Modify a 'CRef' using a compare-and-swap.
-    | WriteCRef CRefId
-    -- ^ Write to a 'CRef' without synchronising.
-    | CasCRef CRefId Bool
-    -- ^ Attempt to to a 'CRef' using a compare-and-swap, synchronising
+    | NewIORef IORefId
+    -- ^ Create a new 'IORef'.
+    | ReadIORef IORefId
+    -- ^ Read from a 'IORef'.
+    | ReadIORefCas IORefId
+    -- ^ Read from a 'IORef' for a future compare-and-swap.
+    | ModIORef IORefId
+    -- ^ Modify a 'IORef'.
+    | ModIORefCas IORefId
+    -- ^ Modify a 'IORef' using a compare-and-swap.
+    | WriteIORef IORefId
+    -- ^ Write to a 'IORef' without synchronising.
+    | CasIORef IORefId Bool
+    -- ^ Attempt to to a 'IORef' using a compare-and-swap, synchronising
     -- it.
-    | CommitCRef ThreadId CRefId
-    -- ^ Commit the last write to the given 'CRef' by the given thread,
+    | CommitIORef ThreadId IORefId
+    -- ^ Commit the last write to the given 'IORef' by the given thread,
     -- so that all threads can see the updated value.
     | STM TTrace [ThreadId]
     -- ^ An STM transaction was executed, possibly waking up some
@@ -210,13 +210,13 @@ continuation to call when it is done:
     | forall a. ATakeMVar    (MVar r a) (a -> Action n r)
     | forall a. ATryTakeMVar (MVar r a) (Maybe a -> Action n r)
 
-    | forall a.   ANewCRef String a (CRef r a -> Action n r)
-    | forall a.   AReadCRef    (CRef r a) (a -> Action n r)
-    | forall a.   AReadCRefCas (CRef r a) (Ticket a -> Action n r)
-    | forall a b. AModCRef     (CRef r a) (a -> (a, b)) (b -> Action n r)
-    | forall a b. AModCRefCas  (CRef r a) (a -> (a, b)) (b -> Action n r)
-    | forall a.   AWriteCRef   (CRef r a) a (Action n r)
-    | forall a.   ACasCRef     (CRef r a) (Ticket a) a ((Bool, Ticket a) -> Action n r)
+    | forall a.   ANewIORef String a (IORef r a -> Action n r)
+    | forall a.   AReadIORef    (IORef r a) (a -> Action n r)
+    | forall a.   AReadIORefCas (IORef r a) (Ticket a -> Action n r)
+    | forall a b. AModIORef     (IORef r a) (a -> (a, b)) (b -> Action n r)
+    | forall a b. AModIORefCas  (IORef r a) (a -> (a, b)) (b -> Action n r)
+    | forall a.   AWriteIORef   (IORef r a) a (Action n r)
+    | forall a.   ACasIORef     (IORef r a) (Ticket a) a ((Bool, Ticket a) -> Action n r)
 
     | forall e.   Exception e => AThrow e
     | forall e.   Exception e => AThrowTo ThreadId e (Action n r)
@@ -229,7 +229,7 @@ continuation to call when it is done:
     | ALift (n (Action n r))
     | AYield  (Action n r)
     | AReturn (Action n r)
-    | ACommit ThreadId CRefId
+    | ACommit ThreadId IORefId
     | AStop (n ())
 
     | forall a. ASub (M n r a) (Either Failure a -> Action n r)
@@ -293,9 +293,9 @@ variable ID", this is a naming convention from the past which I
 haven't updated yet.
 
 The tricky bit here is ``synchronised``.  It means that this action
-imposes a *memory barrier*: any uncommitted ``CRef`` writes get
+imposes a *memory barrier*: any uncommitted ``IORef`` writes get
 flushed when this action is performed.  Pretty much everything other
-than a couple of ``CRef`` operations impose a memory barrier.
+than a couple of ``IORef`` operations impose a memory barrier.
 Incidentally, this is what the ``SynchronisedWrite`` we mentioned
 above refers to.
 

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -24,7 +24,7 @@ The available settings are:
 * **"Way"**, how to explore the behaviours of the program under test.
 
 * **Memory model**, which affects how non-synchronised operations,
-  such as ``readCRef`` and ``writeCRef`` behave.
+  such as ``readIORef`` and ``writeIORef`` behave.
 
 * **Discarding**, which allows throwing away uninteresting results,
   rather than keeping them around in memory.

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,10 +27,10 @@ There are a few different packages under the Déjà Fu umbrella:
 .. csv-table::
    :header: "Package", "Version", "Summary"
 
-   ":hackage:`concurrency`",  "1.5.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.10.1.0", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "1.2.0.5",  "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "1.2.0.6",  "Déjà Fu support for the tasty test framework"
+   ":hackage:`concurrency`",  "1.6.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
+   ":hackage:`dejafu`",       "1.11.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "1.2.0.6",  "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "1.2.0.7",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/doc/refinement_testing.rst
+++ b/doc/refinement_testing.rst
@@ -103,7 +103,7 @@ functions.  These functions are:
 The signatures can have different state types, as long as the seed and
 observation types are the same.  This lets you compare different
 implementations of the same idea: for example, comparing a concurrent
-stack implemented using ``MVar`` with one implemented using ``CRef``.
+stack implemented using ``MVar`` with one implemented using ``IORef``.
 
 Properties can have parameters, given in the obvious way:
 

--- a/doc/typeclass.rst
+++ b/doc/typeclass.rst
@@ -32,21 +32,17 @@ process:
 
    * ``TVar`` becomes ``TVar stm``
    * ``MVar`` becomes ``MVar m``
-   * ``IORef`` becomes ``CRef m`` [#]_
+   * ``IORef`` becomes ``IORef m``
 
 5. Some functions are renamed:
 
-   * ``*IORef*`` becomes ``*CRef*``
    * ``forkIO*`` becomes ``fork*``
-   * ``atomicModifyIORefCAS*`` becomes ``modifyCRefCAS*``
+   * ``atomicModifyIORefCAS*`` becomes ``modifyIORefCAS*``
 
 6. Fix the type errors
 
 If you're lucky enough to be starting a new concurrent Haskell
 project, you can just program against the ``MonadConc`` interface.
-
-.. [#] I felt that calling it ``IORef`` when there was no I/O involved
-        would be confusing, but this was perhaps a mistake.
 
 
 What if I really need I/O?

--- a/doc/unit_testing.rst
+++ b/doc/unit_testing.rst
@@ -38,9 +38,9 @@ bugs.  Here they are:
 
   nondeterministic :: forall m. MonadConc m => m Int
   nondeterministic = do
-    var <- newCRef 0
+    var <- newIORef 0
     let settings = (defaultUpdateSettings :: UpdateSettings m ())
-          { updateAction = atomicModifyCRef var (\x -> (x+1, x)) }
+          { updateAction = atomicModifyIORef var (\x -> (x+1, x)) }
     auto <- mkAutoUpdate settings
     auto
     auto

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.0.6 (2018-07-01)
+--------------------
+
+* Git: :tag:`hunit-dejafu-1.2.0.6`
+* Hackage: :hackage:`hunit-dejafu-1.2.0.6`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.12.
+
+
 1.2.0.5 (2018-06-17)
 --------------------
 

--- a/hunit-dejafu/Test/HUnit/DejaFu.hs
+++ b/hunit-dejafu/Test/HUnit/DejaFu.hs
@@ -115,7 +115,7 @@ testAutoWay :: (Eq a, Show a)
   => Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> Conc.ConcIO a
   -- ^ The computation to test.
   -> Test
@@ -157,7 +157,7 @@ testDejafuWay :: Show b
   => Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
@@ -191,7 +191,7 @@ testDejafuDiscard :: Show b
   -> Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
@@ -224,7 +224,7 @@ testDejafusWay :: Show b
   => Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
   -> Conc.ConcIO a
@@ -255,7 +255,7 @@ testDejafusDiscard :: Show b
   -> Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
   -> Conc.ConcIO a

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             1.2.0.5
+version:             1.2.0.6
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-1.2.0.5
+  tag:      hunit-dejafu-1.2.0.6
 
 library
   exposed-modules:     Test.HUnit.DejaFu
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.9 && <5
                      , exceptions >=0.7 && <0.11
-                     , dejafu     >=1.5 && <1.11
+                     , dejafu     >=1.5 && <1.12
                      , HUnit      >=1.3.1 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.0.7 (2018-07-01)
+--------------------
+
+* Git: :tag:`tasty-dejafu-1.2.0.7`
+* Hackage: :hackage:`tasty-dejafu-1.2.0.7`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.12.
+
+
 1.2.0.6 (2018-06-17)
 --------------------
 

--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -148,7 +148,7 @@ testAutoWay :: (Eq a, Show a)
   => Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> Conc.ConcIO a
   -- ^ The computation to test.
   -> TestTree
@@ -190,7 +190,7 @@ testDejafuWay :: Show b
   => Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> TestName
   -- ^ The name of the test.
   -> ProPredicate a b
@@ -224,7 +224,7 @@ testDejafuDiscard :: Show b
   -> Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> String
   -- ^ The name of the test.
   -> ProPredicate a b
@@ -257,7 +257,7 @@ testDejafusWay :: Show b
   => Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> [(TestName, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
   -> Conc.ConcIO a
@@ -288,7 +288,7 @@ testDejafusDiscard :: Show b
   -> Way
   -- ^ How to execute the concurrent program.
   -> MemType
-  -- ^ The memory model to use for non-synchronised @CRef@ operations.
+  -- ^ The memory model to use for non-synchronised @IORef@ operations.
   -> [(TestName, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
   -> Conc.ConcIO a

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             1.2.0.6
+version:             1.2.0.7
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,14 +30,14 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-1.2.0.6
+  tag:      tasty-dejafu-1.2.0.7
 
 library
   exposed-modules:     Test.Tasty.DejaFu
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.9  && <5
-                     , dejafu >=1.5  && <1.11
+                     , dejafu >=1.5  && <1.12
                      , random >=1.0  && <1.2
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.2


### PR DESCRIPTION
## Summary

Global replace of `CRef` to `IORef`, also adds a new (deprecated) `Control.Concurrent.Classy.CRef` module which exposes functions using the old names.

**Related issues:** closes #274
