### PR TITLE
contravariant-1.5

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.6.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.11.0.0 | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 1.11.0.1 | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 1.2.0.6  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 1.2.0.7  | Deja Fu support for the Tasty test framework. |
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,15 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`contravariant` is <1.6.
+
+
 1.11.0.0 - IORefs (2018-07-01)
 ------------------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.11.0.1 (2018-07-02)
+---------------------
+
+* Git: :tag:`dejafu-1.11.0.1`
+* Hackage: :hackage:`dejafu-1.11.0.1`
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.11.0.0
+version:             1.11.0.1
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.11.0.0
+  tag:      dejafu-1.11.0.1
 
 library
   exposed-modules:     Test.DejaFu

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -60,7 +60,7 @@ library
   build-depends:       base              >=4.9 && <5
                      , concurrency       >=1.6 && <1.7
                      , containers        >=0.5 && <0.6
-                     , contravariant     >=1.2 && <1.5
+                     , contravariant     >=1.2 && <1.6
                      , deepseq           >=1.1 && <2
                      , exceptions        >=0.7 && <0.11
                      , leancheck         >=0.6 && <0.8

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.6.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.11.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "1.11.0.1", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "1.2.0.6",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "1.2.0.7",  "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
## Summary

Bump the upper bound of `contravariant` to `<1.6`.

**Related issues:** https://github.com/commercialhaskell/stackage/issues/3782
