### PR TITLE
Continuous deployment to Hackage

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -12,6 +12,9 @@
 # Don't prefer TupleSections
 - ignore: {name: Use tuple-section}
 
+# I don't think this helps
+- ignore: {name: "Avoid lambda using `infix`"}
+
 # Inapplicable
 - ignore: {name: Use readTVarIO, within: Control.Monad.Conc.Class}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,7 @@ jobs:
   - env: MODE=test RESOLVER=lts-10.0           # GHC 8.2
   - env: MODE=test RESOLVER=nightly-2018-03-23 # GHC 8.4
   - env: MODE=test RESOLVER=nightly
+
+  - stage: predeploy
+    if: branch=master
+    env: MODE=predeploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
   allow_failures:
   - env: MODE=test RESOLVER=nightly
 
+env:
+  secure: lpaUGUVI96HQ3Q++n8BHAbKE1l4U3g4NR4V40CCQYj0+RNHbdMmoKNA5kI65j6yFxVmLNdYp4NRRayyqb9UHrAVRCQiBnd94Mv4id6/M13JzF7UNCsUP0lbcNj86Zlce0lwUdnIWVS6OG0PHWQEPSUu0Hs5tPixfK7A0QXC01Cs=
+
 script: ./.travis/$MODE
 
 jobs:
@@ -42,3 +45,7 @@ jobs:
   - stage: predeploy
     if: branch=master
     env: MODE=predeploy
+
+  - stage: deploy
+    if: branch=master AND type != pull_request
+    env: MODE=deploy

--- a/.travis/deploy
+++ b/.travis/deploy
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+source .travis/setup.sh
+
+for pkg in concurrency dejafu hunit-dejafu tasty-dejafu; do
+  echo "barrucadu\n${HACKAGE_PASSWORD}\nn" | $stack upload $pkg
+done

--- a/.travis/predeploy
+++ b/.travis/predeploy
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+function msg {
+  pkg=$1
+  file=$2
+  note=$3
+  if [[ -z "$note" ]]; then
+    echo "${pkg}: package version mismatch in ${file}" >&2
+  else
+    echo "${pkg}: package version mismatch in ${file} (${note})" >&2
+  fi
+}
+
+fail=false
+
+for pkg in concurrency dejafu hunit-dejafu tasty-dejafu; do
+  ver=`grep '^version:' ${pkg}/${pkg}.cabal | sed 's/^version: *//'`
+
+  if ! grep -q -E "tag: *${pkg}-${ver}" $pkg/$pkg.cabal; then
+    msg $pkg $pkg/$pkg.cabal
+    fail=true
+  fi
+
+  if ! grep -q "^${ver}" $pkg/CHANGELOG.rst; then
+    msg $pkg $pkg/CHANGELOG.rst "missing header"
+    fail=true
+  fi
+
+  if ! grep -q -E "Git.*${pkg}-${ver}" $pkg/CHANGELOG.rst; then
+    msg $pkg $pkg/CHANGELOG.rst "missing git tag"
+    fail=true
+  fi
+
+  if ! grep -q -E "Hackage.*${pkg}-${ver}" $pkg/CHANGELOG.rst; then
+    msg $pkg $pkg/CHANGELOG.rst "missing hackage link"
+    fail=true
+  fi
+
+  if ! grep -q -E "${pkg}.*${ver}" README.markdown; then
+    msg $pkg README.markdown
+    fail=true
+  fi
+
+  if ! grep -q -E "${pkg}.*${ver}" doc/getting_started.rst; then
+    msg $pkg doc/getting_started.rst
+    fail=true
+  fi
+
+  if git grep -q unreleased $pkg; then
+    echo "${pkg}: 'unreleased' appears in source" >&2
+    fail=true
+  fi
+done
+
+if $fail; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

This PR adds two new Travis jobs:

- `predeploy`, run on master and on PRs, which checks that version numbers are consistent in tags, the README file, and the getting started page; and also looks for "unreleased".

- `deploy`, run on master, which uploads all the packages to Hackage.

It does *not* create new tags, as I haven't figured that bit out yet, and honestly this gets us most of the way there to a nice CD solution.

**Related issues:** closes #261
