### PR TITLE
Set upper bound on profunctors to <6

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.6.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.11.0.1 | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 1.11.0.2 | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 1.2.0.6  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 1.2.0.7  | Deja Fu support for the Tasty test framework. |
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.11.0.2 (2018-07-08)
+---------------------
+
+* Git: :tag:`dejafu-1.11.0.2`
+* Hackage: :hackage:`dejafu-1.11.0.2`
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,15 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`profunctors` is <6.
+
+
 1.11.0.1 (2018-07-02)
 ---------------------
 

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -64,7 +64,7 @@ library
                      , deepseq           >=1.1 && <2
                      , exceptions        >=0.7 && <0.11
                      , leancheck         >=0.6 && <0.8
-                     , profunctors       >=4.0 && <6.0
+                     , profunctors       >=4.0 && <6
                      , random            >=1.0 && <1.2
                      , transformers      >=0.5 && <0.6
   -- hs-source-dirs:      

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.11.0.1
+version:             1.11.0.2
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.11.0.1
+  tag:      dejafu-1.11.0.2
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.6.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.11.0.1", "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "1.11.0.2", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "1.2.0.6",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "1.2.0.7",  "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
## Summary

`<6.0` matches version 6, so the upper bound should actually be `<6`.

This is potentially a breaking change, but given that there is no `profunctors-6`, and no sign that one is likely to be released, I'm calling it a patch bump.

I'm also using this PR to test out the new predeploy check.

**Related issues:** closes #278 