### PR TITLE
Use lts-12.0 for GHC 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ jobs:
   - env: MODE=lint
 
   - stage: test
-    env: MODE=test RESOLVER=lts-9.0            # GHC 8.0
-  - env: MODE=test RESOLVER=lts-10.0           # GHC 8.2
-  - env: MODE=test RESOLVER=nightly-2018-03-23 # GHC 8.4
+    env: MODE=test RESOLVER=lts-9.0  # GHC 8.0
+  - env: MODE=test RESOLVER=lts-10.0 # GHC 8.2
+  - env: MODE=test RESOLVER=lts-12.0 # GHC 8.4
   - env: MODE=test RESOLVER=nightly
 
   - stage: predeploy

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -8,7 +8,7 @@ The currently supported versions are:
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
-   "8.4",  "",         "4.11.0.0"
+   "8.4",  "LTS 12.0", "4.11.0.0"
    "8.2",  "LTS 10.0", "4.10.1.0"
    "8.0",  "LTS 9.0",  "4.9.1.0"
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.0
+resolver: lts-12.0
 
 packages:
 - concurrency


### PR DESCRIPTION
## Summary

Now that lts-12 is out, we can use that as our supported thing for GHC 8.4.