### PR TITLE
Only collapse commits and barriers where sound

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.6.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.11.0.2 | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 1.11.0.3 | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 1.2.0.6  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 1.2.0.7  | Deja Fu support for the Tasty test framework. |
 

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -442,7 +442,7 @@ genSynchronisedActionType = HGen.choice
 
 genDepState :: H.Gen SCT.DepState
 genDepState = SCT.DepState
-  <$> genSmallMap genIORefId HGen.bool
+  <$> genSmallMap genIORefId genSmallInt
   <*> genSmallSet genMVarId
   <*> genSmallMap genThreadId genMaskingState
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,16 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Fixed
+~~~~~
+
+* (:issue:`275`) In trace simplification, only remove a commit if
+  there are no other buffered writes for that same `IORef`.
+
+
 1.11.0.2 (2018-07-08)
 ---------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.11.0.3 (2018-07-15)
+---------------------
+
+* Git: :tag:`dejafu-1.11.0.3`
+* Hackage: :hackage:`dejafu-1.11.0.3`
 
 Fixed
 ~~~~~

--- a/dejafu/Test/DejaFu/SCT/Internal.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal.hs
@@ -244,8 +244,8 @@ permuteBy safeIO memtype = go initialDepState where
 dropCommits :: Bool -> MemType -> [(ThreadId, ThreadAction)] -> [(ThreadId, ThreadAction)]
 dropCommits _ SequentialConsistency = id
 dropCommits safeIO memtype = go initialDepState where
-  go ds (t1@(tid1, ta1@(CommitIORef _ _)):t2@(tid2, ta2):trc)
-    | isBarrier (simplifyAction ta2) = go ds (t2:trc)
+  go ds (t1@(tid1, ta1@(CommitIORef _ iorefid)):t2@(tid2, ta2):trc)
+    | isBarrier (simplifyAction ta2) && numBuffered ds iorefid == 1 = go ds (t2:trc)
     | independent safeIO ds tid1 ta1 tid2 ta2 = t2 : go (updateDepState memtype ds tid2 ta2) (t1:trc)
   go ds (t@(tid,ta):trc) = t : go (updateDepState memtype ds tid ta) trc
   go _ [] = []

--- a/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
@@ -705,18 +705,18 @@ initialDepState = DepState M.empty S.empty M.empty
 -- happened.
 updateDepState :: MemType -> DepState -> ThreadId -> ThreadAction -> DepState
 updateDepState memtype depstate tid act = DepState
-  { depIOState   = updateCRState memtype act $ depIOState   depstate
+  { depIOState   = updateIOState memtype act $ depIOState   depstate
   , depMVState   = updateMVState         act $ depMVState   depstate
   , depMaskState = updateMaskState tid   act $ depMaskState depstate
   }
 
 -- | Update the @IORef@ buffer state with the action that has just
 -- happened.
-updateCRState :: MemType -> ThreadAction -> Map IORefId Bool -> Map IORefId Bool
-updateCRState SequentialConsistency _ = const M.empty
-updateCRState _ (CommitIORef _ r) = M.delete r
-updateCRState _ (WriteIORef    r) = M.insert r True
-updateCRState _ ta
+updateIOState :: MemType -> ThreadAction -> Map IORefId Bool -> Map IORefId Bool
+updateIOState SequentialConsistency _ = const M.empty
+updateIOState _ (CommitIORef _ r) = M.delete r
+updateIOState _ (WriteIORef    r) = M.insert r True
+updateIOState _ ta
   | isBarrier $ simplifyAction ta = const M.empty
   | otherwise = id
 

--- a/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- |
@@ -9,7 +10,7 @@
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
--- Portability : DeriveAnyClass, DeriveGeneric, FlexibleContexts, ViewPatterns
+-- Portability : DeriveAnyClass, DeriveGeneric, FlexibleContexts, LambdaCase, ViewPatterns
 --
 -- Internal types and functions for SCT via dynamic partial-order
 -- reduction.  This module is NOT considered to form part of the
@@ -680,7 +681,7 @@ dependentActions ds a1 a2 = case (a1, a2) of
 -- ** Dependency function state
 
 data DepState = DepState
-  { depIOState :: Map IORefId Bool
+  { depIOState :: Map IORefId Int
   -- ^ Keep track of which @IORef@s have buffered writes.
   , depMVState :: Set MVarId
   -- ^ Keep track of which @MVar@s are full.
@@ -712,10 +713,13 @@ updateDepState memtype depstate tid act = DepState
 
 -- | Update the @IORef@ buffer state with the action that has just
 -- happened.
-updateIOState :: MemType -> ThreadAction -> Map IORefId Bool -> Map IORefId Bool
+updateIOState :: MemType -> ThreadAction -> Map IORefId Int -> Map IORefId Int
 updateIOState SequentialConsistency _ = const M.empty
-updateIOState _ (CommitIORef _ r) = M.delete r
-updateIOState _ (WriteIORef    r) = M.insert r True
+updateIOState _ (CommitIORef _ r) = (`M.alter` r) $ \case
+  Just 1  -> Nothing
+  Just n  -> Just (n-1)
+  Nothing -> Nothing
+updateIOState _ (WriteIORef    r) = M.insertWith (+) r 1
 updateIOState _ ta
   | isBarrier $ simplifyAction ta = const M.empty
   | otherwise = id
@@ -745,7 +749,11 @@ updateMaskState _ _ = id
 
 -- | Check if a @IORef@ has a buffered write pending.
 isBuffered :: DepState -> IORefId -> Bool
-isBuffered depstate r = M.findWithDefault False r (depIOState depstate)
+isBuffered depstate r = numBuffered depstate r /= 0
+
+-- | Check how many buffered writes an @IORef@ has.
+numBuffered :: DepState -> IORefId -> Int
+numBuffered depstate r = M.findWithDefault 0 r (depIOState depstate)
 
 -- | Check if an @MVar@ is full.
 isFull :: DepState -> MVarId -> Bool

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.11.0.2
+version:             1.11.0.3
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.11.0.2
+  tag:      dejafu-1.11.0.3
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.6.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.11.0.2", "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "1.11.0.3", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "1.2.0.6",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "1.2.0.7",  "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
## Summary

https://github.com/barrucadu/dejafu/blob/35b9be3163c8b6a90cacfde4365d3917916f8748/dejafu/Test/DejaFu/SCT/Internal.hs#L243-L251

This is only sound if there are no buffered writes for that `IORef` from other threads.  This PR implements a slightly overzealous restriction, where it will only remove a commit like that if there are no other buffered writes for that `IORef` at all.

**Related issues:** closes #275