### PR TITLE
Use stackage lts-13 for travis & stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ jobs:
     env: MODE=test RESOLVER=lts-9.0  # GHC 8.0
   - env: MODE=test RESOLVER=lts-10.0 # GHC 8.2
   - env: MODE=test RESOLVER=lts-12.0 # GHC 8.4
+  - env: MODE=test RESOLVER=lts-13.3 # GHC 8.6 - .3 because hedgehog and stylish-haskell aren't in .0
   - env: MODE=test RESOLVER=nightly
 
   - stage: predeploy

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -8,7 +8,7 @@ The currently supported versions are:
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
-   "8.6",  "", "4.12.0.0"
+   "8.6",  "LTS 13.0", "4.12.0.0"
    "8.4",  "LTS 12.0", "4.11.0.0"
    "8.2",  "LTS 10.0", "4.10.1.0"
    "8.0",  "LTS 9.0",  "4.9.1.0"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
-resolver: lts-12.0
+# hedgehog is not in 13.0
+resolver: lts-13.3
 
 packages:
 - concurrency


### PR DESCRIPTION
## Summary

Now that an LTS with GHC 8.6 is out, use it as the default resolver for stack, add it to the Travis build matrix, and update the docs.