### PR TITLE
Split "Failure" type up and distinguish between concurrency "conditions" and dejafu "errors"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,9 +46,9 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.6.2.0  | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 1.11.0.5 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 1.2.0.6  | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 1.2.0.8  | Deja Fu support for the Tasty test framework. |
+| [dejafu][h:dejafu]       | 1.12.0.0 | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 1.2.1.0  | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 1.2.1.0  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/dejafu-tests/lib/Common.hs
+++ b/dejafu-tests/lib/Common.hs
@@ -18,7 +18,7 @@ import qualified Hedgehog                   as H
 import qualified Hedgehog.Gen               as HGen
 import qualified Hedgehog.Range             as HRange
 import           System.Random              (mkStdGen)
-import           Test.DejaFu                (Failure, Predicate,
+import           Test.DejaFu                (Condition, Predicate,
                                              ProPredicate(..), Result(..), Way,
                                              alwaysTrue, somewhereTrue)
 import           Test.DejaFu.Conc           (ConcIO, randomSched, runConcurrent)
@@ -101,10 +101,10 @@ djfuE name e0 c = toTestList . TH.testCase name $ C.catch
     msg = "expected " ++ displayException e0
     err e = msg ++ " got " ++ displayException e
 
-alwaysFailsWith :: (Failure -> Bool) -> Predicate a
+alwaysFailsWith :: (Condition -> Bool) -> Predicate a
 alwaysFailsWith p = alwaysTrue (either p (const False))
 
-sometimesFailsWith :: (Failure -> Bool) -> Predicate a
+sometimesFailsWith :: (Condition -> Bool) -> Predicate a
 sometimesFailsWith p = somewhereTrue (either p (const False))
 
 testProperty :: String -> H.PropertyT IO () -> T.TestTree

--- a/dejafu-tests/lib/Examples/AutoUpdate.hs
+++ b/dejafu-tests/lib/Examples/AutoUpdate.hs
@@ -44,7 +44,7 @@ import           Control.Monad.Conc.Class
 
 -- test imports
 import           Common
-import           Test.DejaFu              (Failure(..), gives)
+import           Test.DejaFu              (Condition(..), gives)
 
 tests :: [TestTree]
 tests = toTestList

--- a/dejafu-tests/lib/Examples/Philosophers.hs
+++ b/dejafu-tests/lib/Examples/Philosophers.hs
@@ -11,7 +11,9 @@ import           Common
 tests :: [TestTree]
 tests =
   [ testDejafuWay way defaultMemType "deadlocks" deadlocksSometimes (philosophers 3)
-  , testDejafuWay way defaultMemType "loops"     abortsSometimes    (philosophers 3)
+  , let settings = set lshowAborts True (fromWayAndMemType way defaultMemType)
+    in testDejafuWithSettings settings "loops (with aborts present)" abortsSometimes (philosophers 3)
+  , expectFail $ testDejafuWay way defaultMemType "loops (with aborts hidden)" abortsSometimes (philosophers 3)
   ]
 
 -- | Shorter execution length bound

--- a/dejafu-tests/lib/Integration/MultiThreaded.hs
+++ b/dejafu-tests/lib/Integration/MultiThreaded.hs
@@ -7,6 +7,7 @@ import           Control.Monad.IO.Class    (liftIO)
 import           System.Random             (mkStdGen)
 import           Test.DejaFu               (Failure(..), gives, gives',
                                             isUncaughtException)
+import           Test.DejaFu.Types         (Error(..))
 
 import           Control.Concurrent.Classy
 import qualified Data.IORef                as IORef
@@ -302,7 +303,7 @@ hacksTests = toTestList
           _ <- fork $ takeMVar var >>= putMVar out
           takeMVar out
 
-    , djfuTS "It is illegal to start subconcurrency after forking" (gives [Left IllegalSubconcurrency]) $ do
+    , djfuE "It is illegal to start subconcurrency after forking" MultithreadedSubconcurrency $ do
         var <- newEmptyMVar
         _ <- fork $ readMVar var
         _ <- subconcurrency $ pure ()

--- a/dejafu-tests/lib/Integration/MultiThreaded.hs
+++ b/dejafu-tests/lib/Integration/MultiThreaded.hs
@@ -5,7 +5,7 @@ import           Control.Exception         (ArithException(..))
 import           Control.Monad             (replicateM, void)
 import           Control.Monad.IO.Class    (liftIO)
 import           System.Random             (mkStdGen)
-import           Test.DejaFu               (Failure(..), gives, gives',
+import           Test.DejaFu               (Condition(..), gives, gives',
                                             isUncaughtException)
 import           Test.DejaFu.Types         (Error(..))
 

--- a/dejafu-tests/lib/Integration/SCT.hs
+++ b/dejafu-tests/lib/Integration/SCT.hs
@@ -11,7 +11,7 @@ import qualified Data.Set                  as S
 import           System.Random             (mkStdGen)
 import           Test.DejaFu               (gives')
 import           Test.DejaFu.SCT
-import           Test.DejaFu.Types         (Failure(..))
+import           Test.DejaFu.Types         (Condition(..))
 import           Test.Tasty.HUnit
 
 import           Common

--- a/dejafu-tests/lib/Integration/SingleThreaded.hs
+++ b/dejafu-tests/lib/Integration/SingleThreaded.hs
@@ -5,9 +5,9 @@ module Integration.SingleThreaded where
 import           Control.Exception         (ArithException(..),
                                             ArrayException(..))
 import           Test.DejaFu               (Failure(..), gives, gives', isAbort,
-                                            isDeadlock, isIllegalDontCheck,
-                                            isUncaughtException)
+                                            isDeadlock, isUncaughtException)
 import           Test.DejaFu.Settings      (defaultLengthBound)
+import           Test.DejaFu.Types         (Error(..))
 
 import           Control.Concurrent.Classy
 import           Control.Monad             (replicateM_)
@@ -275,7 +275,7 @@ hacksTests = toTestList
     , djfu "Failures abort the whole computation" (alwaysFailsWith isDeadlock) $
         dontCheck Nothing $ takeMVar =<< newEmptyMVarInt
 
-    , djfu "Must be the very first thing" (alwaysFailsWith isIllegalDontCheck) $ do
+    , djfuE "Must be the very first thing" LateDontCheck $ do
         v <- newEmptyMVarInt
         dontCheck Nothing $ putMVar v 5
 

--- a/dejafu-tests/lib/Integration/SingleThreaded.hs
+++ b/dejafu-tests/lib/Integration/SingleThreaded.hs
@@ -4,8 +4,9 @@ module Integration.SingleThreaded where
 
 import           Control.Exception         (ArithException(..),
                                             ArrayException(..))
-import           Test.DejaFu               (Failure(..), gives, gives', isAbort,
-                                            isDeadlock, isUncaughtException)
+import           Test.DejaFu               (Condition(..), gives, gives',
+                                            isAbort, isDeadlock,
+                                            isUncaughtException)
 import           Test.DejaFu.Settings      (defaultLengthBound)
 import           Test.DejaFu.Types         (Error(..))
 

--- a/dejafu-tests/lib/Unit/Predicates.hs
+++ b/dejafu-tests/lib/Unit/Predicates.hs
@@ -20,9 +20,9 @@ alwaysSameBy :: [TestTree]
 alwaysSameBy = toTestList
   [ passes "Equal successes"   (D.alwaysSameBy (==)) [Right 1, Right 1, Right 1]
   , fails  "Unequal successes" (D.alwaysSameBy (==)) [Right 1, Right 2, Right 3]
-  , fails  "Equal failures"    (D.alwaysSameBy (==)) [Left D.Deadlock, Left D.Deadlock, Left D.Deadlock]
-  , fails  "Unequal failures"  (D.alwaysSameBy (==)) [Left D.Deadlock, Left D.STMDeadlock, Left D.Abort]
-  , fails  "Mixed failures and successes" (D.alwaysSameBy (==)) [Left D.Deadlock, Right 1, Right 1]
+  , fails  "Equal conditions"   (D.alwaysSameBy (==)) [Left D.Deadlock, Left D.Deadlock, Left D.Deadlock]
+  , fails  "Unequal conditions" (D.alwaysSameBy (==)) [Left D.Deadlock, Left D.STMDeadlock, Left D.Abort]
+  , fails  "Mixed conditions and successes" (D.alwaysSameBy (==)) [Left D.Deadlock, Right 1, Right 1]
   ]
 
 -------------------------------------------------------------------------------
@@ -31,9 +31,9 @@ notAlwaysSameBy :: [TestTree]
 notAlwaysSameBy = toTestList
   [ fails  "Equal successes"   (D.notAlwaysSameBy (==)) [Right 1, Right 1, Right 1]
   , passes "Unequal successes" (D.notAlwaysSameBy (==)) [Right 1, Right 2, Right 3]
-  , fails  "Equal failures"    (D.notAlwaysSameBy (==)) [Left D.Deadlock, Left D.Deadlock, Left D.Deadlock]
-  , fails  "Unequal failures"  (D.notAlwaysSameBy (==)) [Left D.Deadlock, Left D.STMDeadlock, Left D.Abort]
-  , fails  "Mixed failures and successes" (D.notAlwaysSameBy (==)) [Left D.Deadlock, Right 1, Right 1]
+  , fails  "Equal conditions"   (D.notAlwaysSameBy (==)) [Left D.Deadlock, Left D.Deadlock, Left D.Deadlock]
+  , fails  "Unequal conditions" (D.notAlwaysSameBy (==)) [Left D.Deadlock, Left D.STMDeadlock, Left D.Abort]
+  , fails  "Mixed conditions and successes" (D.notAlwaysSameBy (==)) [Left D.Deadlock, Right 1, Right 1]
   ]
 
 -------------------------------------------------------------------------------
@@ -66,13 +66,13 @@ gives = toTestList
 -------------------------------------------------------------------------------
 
 -- | Check a predicate passes
-passes :: String -> D.Predicate Int -> [Either D.Failure Int] -> TestTree
+passes :: String -> D.Predicate Int -> [Either D.Condition Int] -> TestTree
 passes = checkPredicate D._pass
 
 -- | Check a predicate fails
-fails :: String -> D.Predicate Int -> [Either D.Failure Int] -> TestTree
+fails :: String -> D.Predicate Int -> [Either D.Condition Int] -> TestTree
 fails = checkPredicate (not . D._pass)
 
 -- | Check a predicate
-checkPredicate :: (D.Result Int -> Bool) -> String -> D.Predicate Int -> [Either D.Failure Int] -> TestTree
+checkPredicate :: (D.Result Int -> Bool) -> String -> D.Predicate Int -> [Either D.Condition Int] -> TestTree
 checkPredicate f msg p = testCase msg . assertBool "" . f . D.peval p . map (\efa -> (efa, []))

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -336,11 +336,9 @@ genId = D.Id <$> HGen.maybe genString <*> genSmallInt
 
 genFailure :: H.Gen D.Failure
 genFailure = HGen.element $
-  [ D.InternalError
-  , D.Abort
+  [ D.Abort
   , D.Deadlock
   , D.STMDeadlock
-  , D.IllegalSubconcurrency
   ] ++ map D.UncaughtException -- have a few different exception types
   [ E.toException E.Overflow
   , E.toException E.ThreadKilled

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -34,9 +34,9 @@ tests =
 
 classLawProps :: [TestTree]
 classLawProps = toTestList
-    [ testGroup "Id"      (eqord genId)
-    , testGroup "Failure" (eqord genFailure)
-    , testGroup "Weaken"  (discardf min D.getWeakDiscarder)
+    [ testGroup "Id"         (eqord genId)
+    , testGroup "Condition"  (eqord genCondition)
+    , testGroup "Weaken"     (discardf min D.getWeakDiscarder)
     , testGroup "Strengthen" (discardf max D.getStrongDiscarder)
     ]
   where
@@ -334,8 +334,8 @@ genTVarId = D.TVarId <$> genId
 genId :: H.Gen D.Id
 genId = D.Id <$> HGen.maybe genString <*> genSmallInt
 
-genFailure :: H.Gen D.Failure
-genFailure = HGen.element $
+genCondition :: H.Gen D.Condition
+genCondition = HGen.element $
   [ D.Abort
   , D.Deadlock
   , D.STMDeadlock
@@ -444,11 +444,11 @@ genDepState = SCT.DepState
   <*> genSmallSet genMVarId
   <*> genSmallMap genThreadId genMaskingState
 
-genDiscarder :: H.Gen (Function (Either D.Failure Int) (Maybe D.Discard))
+genDiscarder :: H.Gen (Function (Either D.Condition Int) (Maybe D.Discard))
 genDiscarder = genFunction genEfa (HGen.maybe genDiscard)
 
-genEfa :: H.Gen (Either D.Failure Int)
-genEfa = genEither genFailure genSmallInt
+genEfa :: H.Gen (Either D.Condition Int)
+genEfa = genEither genCondition genSmallInt
 
 genDiscard :: H.Gen D.Discard
 genDiscard = HGen.element

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -18,6 +18,9 @@ Added
     * ``Test.DejaFu.Types.isSchedulerError``
     * ``Test.DejaFu.Types.isIncorrectUsage``
 
+* Deprecated ``Test.DejaFu.Types.Failure`` type synonym for
+  ``Condition``.
+
 Changed
 ~~~~~~~
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.12.0.0 (2019-01-20)
+---------------------
+
+* Git: :tag:`dejafu-1.12.0.0`
+* Hackage: :hackage:`dejafu-1.12.0.0`
 
 Added
 ~~~~~
@@ -23,6 +26,8 @@ Added
 
 * The ``Test.DejaFu.Settings.lshowAborts`` option, to make SCT
   functions show ``Abort`` conditions.
+
+* ``Test.DejaFu.Utils.showCondition``
 
 Changed
 ~~~~~~~
@@ -39,6 +44,7 @@ Removed
 * ``Test.DejaFu.Types.isInternalError``
 * ``Test.DejaFu.Types.isIllegalDontCheck``
 * ``Test.DejaFu.Types.isIllegalSubconcurrency``
+* ``Test.DejaFu.Utils.showFail``
 
 
 1.11.0.5 (2019-01-17)

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,25 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Added
+~~~~~
+
+* ``Test.DejaFu.Types.Error`` for internal errors and misuses, with
+  predicates:
+    * ``Test.DejaFu.Types.isSchedulerError``
+    * ``Test.DejaFu.Types.isIncorrectUsage``
+
+Removed
+~~~~~~~
+
+* ``Test.DejaFu.Types.isInternalError``
+* ``Test.DejaFu.Types.isIllegalDontCheck``
+* ``Test.DejaFu.Types.isIllegalSubconcurrency``
+
+
 1.11.0.5 (2019-01-17)
 ---------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -18,6 +18,12 @@ Added
     * ``Test.DejaFu.Types.isSchedulerError``
     * ``Test.DejaFu.Types.isIncorrectUsage``
 
+Changed
+~~~~~~~
+
+* Renamed ``Test.DejaFu.Types.Failure`` to
+  ``Test.DejaFu.Types.Condition``.
+
 Removed
 ~~~~~~~
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -21,11 +21,17 @@ Added
 * Deprecated ``Test.DejaFu.Types.Failure`` type synonym for
   ``Condition``.
 
+* The ``Test.DejaFu.Settings.lshowAborts`` option, to make SCT
+  functions show ``Abort`` conditions.
+
 Changed
 ~~~~~~~
 
 * Renamed ``Test.DejaFu.Types.Failure`` to
   ``Test.DejaFu.Types.Condition``.
+
+* The SCT functions drop ``Left Abort`` results by default, restore
+  the old behaviour with ``Test.DejaFu.Settings.lshowAborts``.
 
 Removed
 ~~~~~~~

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -46,8 +46,8 @@ and, for each, a summarised execution trace leading to that result:
 
  * Each \"-\" represents one \"step\" of the computation.
 
-__Failures:__ If a program doesn't terminate successfully, we say it
-has /failed/.  dejafu can detect a few different types of failure:
+__Conditions:__ A program may fail to terminate in a way which
+produces a value. dejafu can detect a few such cases:
 
  * 'Deadlock', if every thread is blocked.
 
@@ -107,7 +107,7 @@ If you need more information, use these functions.
 -}
 
   , Result(..)
-  , Failure(..)
+  , Condition(..)
   , runTest
   , runTestWay
 
@@ -161,11 +161,11 @@ usage.
   , gives
   , gives'
 
-  -- *** Failures
+  -- *** Conditions
 
   {- |
 
-Helper functions to identify failures.
+Helper functions to identify conditions.
 
 -}
 
@@ -475,7 +475,7 @@ dejafuWithSettings settings name test =
 --
 -- @since 1.0.0.0
 dejafuDiscard :: (MonadConc n, MonadIO n, Show b)
-  => (Either Failure a -> Maybe Discard)
+  => (Either Condition a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> Way
   -- ^ How to run the concurrent program.
@@ -593,7 +593,7 @@ dejafusWithSettings settings tests conc = do
 data Result a = Result
   { _pass :: Bool
   -- ^ Whether the test passed or not.
-  , _failures :: [(Either Failure a, Trace)]
+  , _failures :: [(Either Condition a, Trace)]
   -- ^ The failing cases, if any.
   , _failureMsg :: String
   -- ^ A message to display on failure, if nonempty
@@ -606,7 +606,7 @@ instance NFData a => NFData (Result a) where
               )
 
 -- | A failed result, taking the given list of failures.
-defaultFail :: [(Either Failure a, Trace)] -> Result a
+defaultFail :: [(Either Condition a, Trace)] -> Result a
 defaultFail failures = Result False failures ""
 
 -- | A passed result.
@@ -692,9 +692,9 @@ type Predicate a = ProPredicate a a
 --
 -- @since 1.0.0.0
 data ProPredicate a b = ProPredicate
-  { pdiscard :: Either Failure a -> Maybe Discard
+  { pdiscard :: Either Condition a -> Maybe Discard
   -- ^ Selectively discard results before computing the result.
-  , peval :: [(Either Failure a, Trace)] -> Result b
+  , peval :: [(Either Condition a, Trace)] -> Result b
   -- ^ Compute the result with the un-discarded results.
   }
 
@@ -730,7 +730,7 @@ successful = alwaysTrue (either (const False) (const True))
 
 -- | Check that a computation never aborts.
 --
--- Any result other than an abort, including other 'Failure's, is
+-- Any result other than an abort, including other 'Condition's, is
 -- allowed.
 --
 -- @since 1.0.0.0
@@ -745,7 +745,7 @@ abortsAlways = alwaysTrue $ either (==Abort) (const False)
 
 -- | Check that a computation aborts at least once.
 --
--- Any result other than an abort, including other 'Failure's, is
+-- Any result other than an abort, including other 'Condition's, is
 -- allowed.
 --
 -- @since 1.0.0.0
@@ -754,7 +754,7 @@ abortsSometimes = somewhereTrue $ either (==Abort) (const False)
 
 -- | Check that a computation never deadlocks.
 --
--- Any result other than a deadlock, including other 'Failure's, is
+-- Any result other than a deadlock, including other 'Condition's, is
 -- allowed.
 --
 -- @since 1.0.0.0
@@ -769,7 +769,7 @@ deadlocksAlways = alwaysTrue $ either isDeadlock (const False)
 
 -- | Check that a computation deadlocks at least once.
 --
--- Any result other than a deadlock, including other 'Failure's, is
+-- Any result other than a deadlock, including other 'Condition's, is
 -- allowed.
 --
 -- @since 1.0.0.0
@@ -779,7 +779,7 @@ deadlocksSometimes = somewhereTrue $ either isDeadlock (const False)
 -- | Check that a computation never fails with an uncaught exception.
 --
 -- Any result other than an uncaught exception, including other
--- 'Failure's, is allowed.
+-- 'Condition's, is allowed.
 --
 -- @since 1.0.0.0
 exceptionsNever :: Predicate a
@@ -794,7 +794,7 @@ exceptionsAlways = alwaysTrue $ either isUncaughtException (const False)
 -- | Check that a computation fails with an uncaught exception at least once.
 --
 -- Any result other than an uncaught exception, including other
--- 'Failure's, is allowed.
+-- 'Condition's, is allowed.
 --
 -- @since 1.0.0.0
 exceptionsSometimes :: Predicate a
@@ -886,7 +886,7 @@ notAlwaysSameBy f = ProPredicate
 -- | Check that a @Maybe@-producing function always returns 'Nothing'.
 --
 -- @since 1.0.0.0
-alwaysNothing :: (Either Failure a -> Maybe (Either Failure b)) -> ProPredicate a b
+alwaysNothing :: (Either Condition a -> Maybe (Either Condition b)) -> ProPredicate a b
 alwaysNothing f = ProPredicate
   { pdiscard = maybe (Just DiscardResultAndTrace) (const Nothing) . f
   , peval = \xs ->
@@ -898,14 +898,14 @@ alwaysNothing f = ProPredicate
 -- true.
 --
 -- @since 1.0.0.0
-alwaysTrue :: (Either Failure a -> Bool) -> Predicate a
+alwaysTrue :: (Either Condition a -> Bool) -> Predicate a
 alwaysTrue p = alwaysNothing (\efa -> if p efa then Nothing else Just efa)
 
 -- | Check that a @Maybe@-producing function returns 'Nothing' at
 -- least once.
 --
 -- @since 1.0.0.0
-somewhereNothing :: (Either Failure a -> Maybe (Either Failure b)) -> ProPredicate a b
+somewhereNothing :: (Either Condition a -> Maybe (Either Condition b)) -> ProPredicate a b
 somewhereNothing f = ProPredicate
   { pdiscard = maybe (Just DiscardTrace) (const Nothing) . f
   , peval = \xs ->
@@ -917,14 +917,14 @@ somewhereNothing f = ProPredicate
 -- least once.
 --
 -- @since 1.0.0.0
-somewhereTrue :: (Either Failure a -> Bool) -> Predicate a
+somewhereTrue :: (Either Condition a -> Bool) -> Predicate a
 somewhereTrue p = somewhereNothing (\efa -> if p efa then Nothing else Just efa)
 
 -- | Predicate for when there is a known set of results where every
 -- result must be exhibited at least once.
 --
 -- @since 1.0.0.0
-gives :: (Eq a, Show a) => [Either Failure a] -> Predicate a
+gives :: (Eq a, Show a) => [Either Condition a] -> Predicate a
 gives expected = ProPredicate
     { pdiscard = \efa -> if efa `elem` expected then Just DiscardTrace else Nothing
     , peval = \xs -> go expected [] xs $ defaultFail (failures xs)
@@ -944,7 +944,7 @@ gives expected = ProPredicate
 
     failures = filter (\(r, _) -> r `notElem` expected)
 
--- | Variant of 'gives' that doesn't allow for expected failures.
+-- | Variant of 'gives' that doesn't allow for non-success conditions.
 --
 -- @since 1.0.0.0
 gives' :: (Eq a, Show a) => [a] -> Predicate a
@@ -968,7 +968,7 @@ doTest name result = do
         putStrLn $ _failureMsg result
 
       let failures = _failures result
-      let output = map (\(r, t) -> putStrLn . indent $ either showFail show r ++ " " ++ showTrace t) $ take 5 failures
+      let output = map (\(r, t) -> putStrLn . indent $ either showCondition show r ++ " " ++ showTrace t) $ take 5 failures
       sequence_ $ intersperse (putStrLn "") output
       when (moreThan 5 failures) $
         putStrLn (indent "...")

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -238,6 +238,7 @@ interference we have provided: the left term never empties a full
   , module Test.DejaFu.Refinement
 
   -- * Deprecated
+  , Failure
   , dejafuDiscard
   ) where
 

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -56,28 +56,6 @@ has /failed/.  dejafu can detect a few different types of failure:
 
  * 'UncaughtException', if the main thread is killed by an exception.
 
-There are two types of failure which dejafu itself may raise:
-
- * 'Abort', used in systematic testing (the default) if there are no
-   allowed decisions remaining.  For example, by default any test case
-   which takes more than 250 scheduling points to finish will be
-   aborted.  You can use the 'systematically' function to supply (or
-   disable) your own bounds.
-
- * 'InternalError', used if something goes wrong.  If you get this and
-   aren't using a scheduler you wrote yourself, please [file a
-   bug](https://github.com/barrucadu/dejafu/issues).
-
-Finally, there are two failures which can arise through improper use of
-dejafu:
-
- * 'IllegalDontCheck', the "Test.DejaFu.Conc.dontCheck" function is
-   used as anything other than the fist action in the main thread.
-
- * 'IllegalSubconcurrency', the "Test.DejaFu.Conc.subconcurrency"
-   function is used when multiple threads exist, or is used inside
-   another @subconcurrency@ call.
-
 __Beware of 'liftIO':__ dejafu works by running your test case lots of
 times with different schedules.  If you use 'liftIO' at all, make sure
 that any @IO@ you perform is deterministic when executed in the same
@@ -191,12 +169,9 @@ Helper functions to identify failures.
 
 -}
 
-  , isInternalError
   , isAbort
   , isDeadlock
   , isUncaughtException
-  , isIllegalSubconcurrency
-  , isIllegalDontCheck
 
   -- * Property testing
 

--- a/dejafu/Test/DejaFu/Conc.hs
+++ b/dejafu/Test/DejaFu/Conc.hs
@@ -229,9 +229,8 @@ runConcurrent sched memtype s ma = do
 -- This can only be called in the main thread, when no other threads
 -- exist. Calls to 'subconcurrency' cannot be nested, or placed inside
 -- a call to 'dontCheck'. Violating either of these conditions will
--- result in the computation failing with @IllegalSubconcurrency@.
--- The overall test-case can still succeed if the predicate allows for
--- a failing computation.
+-- result in the computation throwing a @NestedSubconcurrency@ or
+-- @MultithreadedSubconcurrency@ error.
 --
 -- @since 0.6.0.0
 subconcurrency :: ConcT n a -> ConcT n (Either Failure a)
@@ -261,9 +260,8 @@ subconcurrency ma = toConc (ASub (unC ma))
 -- action continue to exist in the main computation.
 --
 -- This must be the first thing done in the main thread.  Violating
--- this condition will result in the computation failing with
--- @IllegalDontCheck@.  The overall test-case can still succeed if the
--- predicate allows for a failing computation.
+-- this condition will result in the computation throwing a
+-- @LateDontCheck@ exception.
 --
 -- If the action fails (deadlock, length bound exceeded, etc), the
 -- whole computation fails.

--- a/dejafu/Test/DejaFu/Conc.hs
+++ b/dejafu/Test/DejaFu/Conc.hs
@@ -53,6 +53,9 @@ module Test.DejaFu.Conc
 
   -- * Scheduling
   , module Test.DejaFu.Schedule
+
+  -- * Deprecated
+  , Failure
   ) where
 
 import           Control.Exception                   (MaskingState(..))

--- a/dejafu/Test/DejaFu/Conc/Internal/Common.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Common.hs
@@ -123,7 +123,7 @@ data Action n =
   | ACommit ThreadId IORefId
   | AStop (n ())
 
-  | forall a. ASub (ModelConc n a) (Either Failure a -> Action n)
+  | forall a. ASub (ModelConc n a) (Either Condition a -> Action n)
   | AStopSub (Action n)
   | forall a. ADontCheck (Maybe Int) (ModelConc n a) (a -> Action n)
 

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -38,11 +38,11 @@ import           Test.DejaFu.Types
 data Settings n a = Settings
   { _way :: Way
   , _memtype :: MemType
-  , _discard :: Maybe (Either Failure a -> Maybe Discard)
+  , _discard :: Maybe (Either Condition a -> Maybe Discard)
   , _debugShow :: Maybe (a -> String)
   , _debugPrint :: Maybe (String -> n ())
   , _debugFatal :: Bool
-  , _earlyExit :: Maybe (Either Failure a -> Bool)
+  , _earlyExit :: Maybe (Either Condition a -> Bool)
   , _equality :: Maybe (a -> a -> Bool)
   , _simplify  :: Bool
   , _safeIO :: Bool

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -46,6 +46,7 @@ data Settings n a = Settings
   , _equality :: Maybe (a -> a -> Bool)
   , _simplify  :: Bool
   , _safeIO :: Bool
+  , _showAborts :: Bool
   }
 
 -- | How to explore the possible executions of a concurrent program.

--- a/dejafu/Test/DejaFu/Refinement.hs
+++ b/dejafu/Test/DejaFu/Refinement.hs
@@ -114,7 +114,7 @@ import           Data.Set                 (Set)
 import qualified Data.Set                 as S
 import           Test.LeanCheck           (Listable(..), concatMapT, mapT)
 
-import           Test.DejaFu.Conc         (ConcIO, Failure, subconcurrency)
+import           Test.DejaFu.Conc         (ConcIO, Condition, subconcurrency)
 import           Test.DejaFu.SCT          (runSCT)
 import           Test.DejaFu.Settings     (defaultMemType, defaultWay)
 
@@ -266,9 +266,9 @@ data FailedProperty o x
     -- ^ The seed for this set of executions.
     , failingArgs  :: [String]
     -- ^ The values of free variables, as strings.
-    , leftResults  :: Set (Maybe Failure, o)
+    , leftResults  :: Set (Maybe Condition, o)
     -- ^ The set of results of the left signature.
-    , rightResults :: Set (Maybe Failure, o)
+    , rightResults :: Set (Maybe Condition, o)
     -- ^ The set of results of the right signature.
     }
   | NoExpectedFailure
@@ -409,7 +409,7 @@ checkWithSeeds seeds (Neg rp) = do
 evalSigWithSeed :: Ord o
   => Sig s o x
   -> x
-  -> IO (Set (Maybe Failure, o))
+  -> IO (Set (Maybe Condition, o))
 evalSigWithSeed sig x = do
   results <- runSCT defaultWay defaultMemType $ do
     s <- initialise sig x

--- a/dejafu/Test/DejaFu/SCT/Internal.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal.hs
@@ -42,10 +42,10 @@ sct :: (MonadConc n, HasCallStack)
   -- ^ Initial state
   -> (s -> Maybe t)
   -- ^ State predicate
-  -> ((Scheduler g -> g -> n (Either Failure a, g, Trace)) -> s -> t -> n (s, Maybe (Either Failure a, Trace)))
+  -> ((Scheduler g -> g -> n (Either Condition a, g, Trace)) -> s -> t -> n (s, Maybe (Either Condition a, Trace)))
   -- ^ Run the computation and update the state
   -> ConcT n a
-  -> n [(Either Failure a, Trace)]
+  -> n [(Either Condition a, Trace)]
 sct settings s0 sfun srun conc
     | canDCSnapshot conc = runForDCSnapshot conc >>= \case
         Just (Right snap, _) -> sct'Snap snap
@@ -87,15 +87,15 @@ sct' :: (MonadConc n, HasCallStack)
   -- ^ Initial state
   -> (s -> Maybe t)
   -- ^ State predicate
-  -> (s -> t -> n (s, Maybe (Either Failure a, Trace)))
+  -> (s -> t -> n (s, Maybe (Either Condition a, Trace)))
   -- ^ Run the computation and update the state
-  -> (forall x. Scheduler x -> x -> n (Either Failure a, x, Trace))
+  -> (forall x. Scheduler x -> x -> n (Either Condition a, x, Trace))
   -- ^ Just run the computation
   -> ThreadId
   -- ^ The first available @ThreadId@
   -> IORefId
   -- ^ The first available @IORefId@
-  -> n [(Either Failure a, Trace)]
+  -> n [(Either Condition a, Trace)]
 sct' settings s0 sfun srun run nTId nCRId = go Nothing [] s0 where
   go (Just res) _ _ | earlyExit res = pure []
   go _ seen !s = case sfun s of
@@ -150,16 +150,16 @@ sct' settings s0 sfun srun run nTId nCRId = go Nothing [] s0 where
 simplifyExecution :: (MonadConc n, HasCallStack)
   => Settings n a
   -- ^ The SCT settings ('Way' is ignored)
-  -> (forall x. Scheduler x -> x -> n (Either Failure a, x, Trace))
+  -> (forall x. Scheduler x -> x -> n (Either Condition a, x, Trace))
   -- ^ Just run the computation
   -> ThreadId
   -- ^ The first available @ThreadId@
   -> IORefId
   -- ^ The first available @IORefId@
-  -> Either Failure a
+  -> Either Condition a
   -- ^ The expected result
   -> Trace
-  -> n (Either Failure a, Trace)
+  -> n (Either Condition a, Trace)
 simplifyExecution settings run nTId nCRId res trace
     | tidTrace == simplifiedTrace = do
         debugPrint ("Simplifying new result '" ++ p res ++ "': no simplification possible!")
@@ -186,11 +186,11 @@ simplifyExecution settings run nTId nCRId res trace
 
 -- | Replay an execution.
 replay :: MonadConc n
-  => (forall x. Scheduler x -> x -> n (Either Failure a, x, Trace))
+  => (forall x. Scheduler x -> x -> n (Either Condition a, x, Trace))
   -- ^ Run the computation
   -> [(ThreadId, ThreadAction)]
   -- ^ The reduced sequence of scheduling decisions
-  -> n (Either Failure a, [(ThreadId, ThreadAction)], Trace)
+  -> n (Either Condition a, [(ThreadId, ThreadAction)], Trace)
 replay run = run (Scheduler (const sched)) where
     sched runnable ((t, Stop):ts) = case findThread t runnable of
       Just t' -> (Just t', ts)

--- a/dejafu/Test/DejaFu/Settings.hs
+++ b/dejafu/Test/DejaFu/Settings.hs
@@ -450,7 +450,7 @@ lsafeIO afb s = (\b -> s {_safeIO = b}) <$> afb (_safeIO s)
 
 -- | A lens into the show-aborts flag.
 --
--- @since unreleased
+-- @since 1.12.0.0
 lshowAborts :: Lens' (Settings n a) Bool
 lshowAborts afb s = (\b -> s {_showAborts = b}) <$> afb (_showAborts s)
 

--- a/dejafu/Test/DejaFu/Settings.hs
+++ b/dejafu/Test/DejaFu/Settings.hs
@@ -203,6 +203,16 @@ module Test.DejaFu.Settings
 
   , lsafeIO
 
+  -- ** Abort conditions
+
+  -- | Occasionally in an execution dejafu will discover that no
+  -- available scheduling decisions are within the specified bounds,
+  -- and aborts the execution to move onto the next.  This is
+  -- signalled by an 'Abort' condition.  By default, abort conditions
+  -- are /not/ returned from the SCT functions.
+
+  , lshowAborts
+
   -- ** Debug output
 
   -- | You can opt to receive debugging messages by setting debugging
@@ -257,6 +267,7 @@ fromWayAndMemType way memtype = Settings
   , _equality = Nothing
   , _simplify = False
   , _safeIO = False
+  , _showAborts = False
   }
 
 -------------------------------------------------------------------------------
@@ -433,6 +444,15 @@ lsimplify afb s = (\b -> s {_simplify = b}) <$> afb (_simplify s)
 -- @since 1.10.1.0
 lsafeIO :: Lens' (Settings n a) Bool
 lsafeIO afb s = (\b -> s {_safeIO = b}) <$> afb (_safeIO s)
+
+-------------------------------------------------------------------------------
+-- Abort conditions
+
+-- | A lens into the show-aborts flag.
+--
+-- @since unreleased
+lshowAborts :: Lens' (Settings n a) Bool
+lshowAborts afb s = (\b -> s {_showAborts = b}) <$> afb (_showAborts s)
 
 -------------------------------------------------------------------------------
 -- Debug output

--- a/dejafu/Test/DejaFu/Settings.hs
+++ b/dejafu/Test/DejaFu/Settings.hs
@@ -118,7 +118,7 @@ module Test.DejaFu.Settings
   -- opportunity to get rid of them early is possibly a great saving
   -- of memory.
   --
-  -- A discard function, which has type @Either Failure a -> Maybe
+  -- A discard function, which has type @Either Condition a -> Maybe
   -- Discard@, can selectively discard results or execution traces
   -- before the schedule exploration finishes, allowing them to be
   -- garbage collected sooner.
@@ -134,8 +134,9 @@ module Test.DejaFu.Settings
 
   -- | Sometimes we don't want to wait for all executions to be
   -- explored, we just want to stop as soon as a particular result is
-  -- found.  An early-exit predicate, which has type @Either Failure a
-  -- -> Bool@, can opt to halt execution when such a result is found.
+  -- found.  An early-exit predicate, which has type @Either Condition
+  -- a -> Bool@, can opt to halt execution when such a result is
+  -- found.
   --
   -- All results found up to, and including, the one which terminates
   -- the exploration are reported.
@@ -394,7 +395,7 @@ lmemtype afb s = (\b -> s {_memtype = b}) <$> afb (_memtype s)
 -- | A lens into the discard function.
 --
 -- @since 1.2.0.0
-ldiscard :: Lens' (Settings n a) (Maybe (Either Failure a -> Maybe Discard))
+ldiscard :: Lens' (Settings n a) (Maybe (Either Condition a -> Maybe Discard))
 ldiscard afb s = (\b -> s {_discard = b}) <$> afb (_discard s)
 
 -------------------------------------------------------------------------------
@@ -403,7 +404,7 @@ ldiscard afb s = (\b -> s {_discard = b}) <$> afb (_discard s)
 -- | A lens into the early-exit predicate.
 --
 -- @since 1.2.0.0
-learlyExit :: Lens' (Settings n a) (Maybe (Either Failure a -> Bool))
+learlyExit :: Lens' (Settings n a) (Maybe (Either Condition a -> Bool))
 learlyExit afb s = (\b -> s {_earlyExit = b}) <$> afb (_earlyExit s)
 
 -------------------------------------------------------------------------------

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -440,7 +440,7 @@ instance NFData Decision
 
 -- | A type synonym for 'Condition', use that instead.
 --
--- @since unreleased
+-- @since 1.12.0.0
 {-# DEPRECATED Failure "The 'Failure' type has been split up into 'Condition' and 'Error', with different semantics." #-}
 type Failure = Condition
 
@@ -450,7 +450,7 @@ type Failure = Condition
 -- The @Eq@, @Ord@, and @NFData@ instances compare/evaluate the
 -- exception with @show@ in the @UncaughtException@ case.
 --
--- @since unreleased
+-- @since 1.12.0.0
 data Condition
   = Abort
   -- ^ The scheduler chose to abort execution. This will be produced
@@ -514,7 +514,7 @@ isUncaughtException _ = False
 -- | An indication that there is a bug in dejafu or you are using it
 -- incorrectly.
 --
--- @since unreleased
+-- @since 1.12.0.0
 data Error
   = ScheduledBlockedThread
   -- ^ Raised as an exception if the scheduler attempts to schedule a
@@ -536,7 +536,7 @@ instance Exception Error
 
 -- | Check if an error is a scheduler error.
 --
--- @since unreleased
+-- @since 1.12.0.0
 isSchedulerError :: Error -> Bool
 isSchedulerError ScheduledBlockedThread = True
 isSchedulerError ScheduledMissingThread = True
@@ -544,7 +544,7 @@ isSchedulerError _ = False
 
 -- | Check if an error is an incorrect usage of dejafu.
 --
--- @since unreleased
+-- @since 1.12.0.0
 isIncorrectUsage :: Error -> Bool
 isIncorrectUsage NestedSubconcurrency = True
 isIncorrectUsage MultithreadedSubconcurrency = True

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -438,6 +438,12 @@ instance NFData Decision
 -------------------------------------------------------------------------------
 -- * Conditions
 
+-- | A type synonym for 'Condition', use that instead.
+--
+-- @since unreleased
+{-# DEPRECATED Failure "The 'Failure' type has been split up into 'Condition' and 'Error', with different semantics." #-}
+type Failure = Condition
+
 -- | An indication of how a concurrent computation terminated, if it
 -- didn't produce a value.
 --

--- a/dejafu/Test/DejaFu/Utils.hs
+++ b/dejafu/Test/DejaFu/Utils.hs
@@ -76,16 +76,16 @@ simplestsBy f = map choose . collect where
   insert' _ _ ([]:_) = undefined
 
 -------------------------------------------------------------------------------
--- * Failures
+-- * Conditions
 
--- | Pretty-print a failure
+-- | Pretty-print a condition
 --
--- @since 0.4.0.0
-showFail :: Failure -> String
-showFail Abort = "[abort]"
-showFail Deadlock = "[deadlock]"
-showFail STMDeadlock = "[stm-deadlock]"
-showFail (UncaughtException exc) = "[" ++ displayException exc ++ "]"
+-- @since unreleased
+showCondition :: Condition -> String
+showCondition Abort = "[abort]"
+showCondition Deadlock = "[deadlock]"
+showCondition STMDeadlock = "[stm-deadlock]"
+showCondition (UncaughtException exc) = "[" ++ displayException exc ++ "]"
 
 -------------------------------------------------------------------------------
 -- * Scheduling

--- a/dejafu/Test/DejaFu/Utils.hs
+++ b/dejafu/Test/DejaFu/Utils.hs
@@ -85,10 +85,7 @@ showFail :: Failure -> String
 showFail Abort = "[abort]"
 showFail Deadlock = "[deadlock]"
 showFail STMDeadlock = "[stm-deadlock]"
-showFail InternalError = "[internal-error]"
 showFail (UncaughtException exc) = "[" ++ displayException exc ++ "]"
-showFail IllegalSubconcurrency = "[illegal-subconcurrency]"
-showFail IllegalDontCheck = "[illegal-dontcheck]"
 
 -------------------------------------------------------------------------------
 -- * Scheduling

--- a/dejafu/Test/DejaFu/Utils.hs
+++ b/dejafu/Test/DejaFu/Utils.hs
@@ -80,7 +80,7 @@ simplestsBy f = map choose . collect where
 
 -- | Pretty-print a condition
 --
--- @since unreleased
+-- @since 1.12.0.0
 showCondition :: Condition -> String
 showCondition Abort = "[abort]"
 showCondition Deadlock = "[deadlock]"

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             1.11.0.5
+version:             1.12.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-1.11.0.5
+  tag:      dejafu-1.12.0.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,9 +28,9 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.6.2.0",  "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "1.11.0.5", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "1.2.0.6",  "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "1.2.0.8",  "Déjà Fu support for the tasty test framework"
+   ":hackage:`dejafu`",       "1.12.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "1.2.1.0",  "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "1.2.1.0",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,24 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.1.0 (2019-01-20)
+--------------------
+
+* Git: :tag:`hunit-dejafu-1.2.1.0`
+* Hackage: :hackage:`hunit-dejafu-1.2.1.0`
+
+Added
+~~~~~
+
+* Re-export of the ``Condition`` type from :hackage:`dejafu`.  If
+  using dejafu < 1.12, this is an alias for ``Failure``.
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.13
+
+
 1.2.0.6 (2018-07-01)
 --------------------
 

--- a/hunit-dejafu/Test/HUnit/DejaFu.hs
+++ b/hunit-dejafu/Test/HUnit/DejaFu.hs
@@ -83,7 +83,7 @@ showCondition = Conc.showCondition
 #else
 -- | An alias for 'Failure'.
 --
--- @since unreleased
+-- @since 1.2.1.0
 type Condition = Failure
 showCondition = Conc.showFail
 #endif

--- a/hunit-dejafu/Test/HUnit/DejaFu.hs
+++ b/hunit-dejafu/Test/HUnit/DejaFu.hs
@@ -40,6 +40,7 @@ module Test.HUnit.DejaFu
   , testDejafusWithSettings
 
   -- ** Re-exports
+  , Condition
   , Predicate
   , ProPredicate(..)
   , module Test.DejaFu.Settings
@@ -80,6 +81,9 @@ showCondition :: Condition -> String
 #if MIN_VERSION_dejafu(1,12,0)
 showCondition = Conc.showCondition
 #else
+-- | An alias for 'Failure'.
+--
+-- @since unreleased
 type Condition = Failure
 showCondition = Conc.showFail
 #endif

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.9 && <5
                      , exceptions >=0.7 && <0.11
-                     , dejafu     >=1.5 && <1.12
+                     , dejafu     >=1.5 && <1.13
                      , HUnit      >=1.3.1 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             1.2.0.6
+version:             1.2.1.0
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-1.2.0.6
+  tag:      hunit-dejafu-1.2.1.0
 
 library
   exposed-modules:     Test.HUnit.DejaFu

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,24 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+1.2.1.0 (2019-01-20)
+--------------------
+
+* Git: :tag:`tasty-dejafu-1.2.1.0`
+* Hackage: :hackage:`tasty-dejafu-1.2.1.0`
+
+Added
+~~~~~
+
+* Re-export of the ``Condition`` type from :hackage:`dejafu`.  If
+  using dejafu < 1.12, this is an alias for ``Failure``.
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <1.13
+
+
 1.2.0.8 (2018-12-02)
 --------------------
 

--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -40,6 +40,7 @@ module Test.Tasty.DejaFu
   , testDejafusWithSettings
 
   -- ** Re-exports
+  , Condition
   , Predicate
   , ProPredicate(..)
   , module Test.DejaFu.Settings
@@ -86,6 +87,9 @@ showCondition :: Condition -> String
 #if MIN_VERSION_dejafu(1,12,0)
 showCondition = Conc.showCondition
 #else
+-- | An alias for 'Failure'.
+--
+-- @since unreleased
 type Condition = Failure
 showCondition = Conc.showFail
 #endif

--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -80,6 +81,14 @@ import           Test.Tasty.Options     (IsOption(..), OptionDescription(..),
                                          lookupOption)
 import           Test.Tasty.Providers   (IsTest(..), singleTest, testFailed,
                                          testPassed)
+
+showCondition :: Condition -> String
+#if MIN_VERSION_dejafu(1,12,0)
+showCondition = Conc.showCondition
+#else
+type Condition = Failure
+showCondition = Conc.showFail
+#endif
 
 --------------------------------------------------------------------------------
 -- Tasty-style unit testing
@@ -219,7 +228,7 @@ testDejafuWithSettings settings name p = testDejafusWithSettings settings [(name
 --
 -- @since 1.0.0.0
 testDejafuDiscard :: Show b
-  => (Either Failure a -> Maybe Discard)
+  => (Either Condition a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> Way
   -- ^ How to execute the concurrent program.
@@ -283,7 +292,7 @@ testDejafusWithSettings = testconc
 --
 -- @since 1.0.1.0
 testDejafusDiscard :: Show b
-  => (Either Failure a -> Maybe Discard)
+  => (Either Condition a -> Maybe Discard)
   -- ^ Selectively discard results.
   -> Way
   -- ^ How to execute the concurrent program.
@@ -337,7 +346,7 @@ testPropertyFor = testprop
 -- Tasty integration
 
 data ConcTest where
-  ConcTest :: Show b => IO [(Either Failure a, Conc.Trace)] -> ([(Either Failure a, Conc.Trace)] -> Result b) -> ConcTest
+  ConcTest :: Show b => IO [(Either Condition a, Conc.Trace)] -> ([(Either Condition a, Conc.Trace)] -> Result b) -> ConcTest
   deriving Typeable
 
 data PropTest where
@@ -397,7 +406,7 @@ showErr res
 
   msg = if null (_failureMsg res) then "" else _failureMsg res ++ "\n"
 
-  failures = intersperse "" . map (\(r, t) -> indent $ either Conc.showFail show r ++ " " ++ Conc.showTrace t) . take 5 $ _failures res
+  failures = intersperse "" . map (\(r, t) -> indent $ either showCondition show r ++ " " ++ Conc.showTrace t) . take 5 $ _failures res
 
   rest = if moreThan (_failures res) 5 then "\n\t..." else ""
 

--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -89,7 +89,7 @@ showCondition = Conc.showCondition
 #else
 -- | An alias for 'Failure'.
 --
--- @since unreleased
+-- @since 1.2.1.0
 type Condition = Failure
 showCondition = Conc.showFail
 #endif

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             1.2.0.8
+version:             1.2.1.0
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-1.2.0.8
+  tag:      tasty-dejafu-1.2.1.0
 
 library
   exposed-modules:     Test.Tasty.DejaFu

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -37,7 +37,7 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.9  && <5
-                     , dejafu >=1.5  && <1.12
+                     , dejafu >=1.5  && <1.13
                      , random >=1.0  && <1.2
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.3


### PR DESCRIPTION
## Summary

By far the single most confusing part of dejafu, which has tripped people up time and time again (eg #230, #257) is that the word "failure" is used for two totally different things:

1. A concurrent computation can "fail" - deadlocking, throwing an exception in the main thread, etc.
2. A test case can "fail" - say that something is wrong.

(2) is a meaning people are familiar with.  (1) is also a reasonable meaning.  The problem is that a failure in the sense of (1) doesn't cause a failure in the sense of (2).  Even worse, we have different types of "failure" under the umbrella of (1), covering both errors in the code under test (eg, a deadlock) *and* an error in dejafu (or your use of it)!

This PR makes a few changes to fix the confusion:

- `Failure` is given a less-loaded name: `Condition` (a deprecated alias for `Failure` is added)
- Conditions signalling a bug in dejafu or your use of it are moved into a new `Error` type, and thrown as an exception if they occur.
- `Abort`, which doesn't quite fit into either camp, is left inside `Condition` but hidden unless the user explicitly opts into seeing them with the new `lshowAborts` option.

**Related issues:** #270 improved the *behaviour* a lot, left the confusing state of affairs for first-time users, who would be "corrected" by the inevitable test failures when they got confused.  By splitting up the types and changing the documentation like this, hopefully that can be avoided.