### PR TITLE
Make (myThreadId >>= killThread) interrupt a mask

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.6.2.0  | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 2.0.0.0 | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 2.0.0.1 | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.0  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 2.0.0.0  | Deja Fu support for the Tasty test framework. |
 

--- a/dejafu-tests/lib/Integration/Regressions.hs
+++ b/dejafu-tests/lib/Integration/Regressions.hs
@@ -56,4 +56,8 @@ tests = toTestList
       _ <- fork (setNumCapabilities 2)
       _ <- fork (setNumCapabilities 3)
       getNumCapabilities
+
+  , djfu "https://github.com/barrucadu/dejafu/issues/267" exceptionsAlways $ do
+      tid <- myThreadId
+      uninterruptibleMask_ (throwTo tid ThreadKilled)
   ]

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,6 +6,18 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+2.0.0.1 (2019-03-14)
+--------------------
+
+* Git: :tag:`dejafu-2.0.0.1`
+* Hackage: :hackage:`dejafu-2.0.0.1`
+
+Fixed
+~~~~~
+
+* (:issue:`267`) Throwing an asynchronous exception to the current
+  thread interrupts the current thread even if it is masked.
+
 
 2.0.0.0 (2019-02-12)
 --------------------

--- a/dejafu/Test/DejaFu/Conc/Internal.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal.hs
@@ -534,7 +534,7 @@ stepThread _ _ _ _ tid (AThrowTo t e c) = synchronised $ \ctx@Context{..} ->
       blocked  = block (OnMask t) tid cThreads
   in case M.lookup t cThreads of
        Just thread
-         | interruptible thread -> stepThrow (ThrowTo t) t e ctx { cThreads = threads' }
+         | interruptible thread || t == tid -> stepThrow (ThrowTo t) t e ctx { cThreads = threads' }
          | otherwise -> pure
            ( Succeeded ctx { cThreads = blocked }
            , BlockedThrowTo t

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             2.0.0.0
+version:             2.0.0.1
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-2.0.0.0
+  tag:      dejafu-2.0.0.1
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.6.2.0",  "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "2.0.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "2.0.0.1", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.0",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "2.0.0.0",  "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
## Summary

From Control.Exception:

> Note that if `throwTo` is called with the current thread as the
> target, the exception will be thrown even if the thread is currently
> inside `mask` or `uninterruptibleMask`.

**Related issues:** fixes #267


## Checklist

**If this is fixing a bug or adding a feature:**

- [x] Add new tests to dejafu-tests