### PR TITLE
Make dejafu pure again

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,10 +45,10 @@ There are a few different packages under the Déjà Fu umbrella:
 
 |   | Version | Summary |
 | - | ------- | ------- |
-| [concurrency][h:conc]    | 1.6.2.0  | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 2.0.0.1 | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 2.0.0.0  | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 2.0.0.0  | Deja Fu support for the Tasty test framework. |
+| [concurrency][h:conc]    | 1.7.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
+| [dejafu][h:dejafu]       | 2.1.0.0  | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 2.0.0.1  | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 2.0.0.1  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.7.0.0 (2019-03-24)
+--------------------
+
+* Git: :tag:`concurrency-1.7.0.0`
+* Hackage: :hackage:`concurrency-1.7.0.0`
 
 Added
 ~~~~~

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,6 +7,22 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Added
+~~~~~
+
+* The ``Control.Monad.Conc.Class.supportsBoundThreads`` function, like
+  ``rtsSupportsBoundThreads`` but returns a monadic result.
+
+Deprecated
+~~~~~~~~~~
+
+* ``Control.Monad.Conc.Class.rtsSupportsBoundThreads``, in favour of
+  ``supportsBoundThreads``.
+
+
 1.6.2.0 (2018-11-28)
 --------------------
 

--- a/concurrency/Control/Monad/Conc/Class.hs
+++ b/concurrency/Control/Monad/Conc/Class.hs
@@ -150,7 +150,7 @@ import qualified Control.Monad.Writer.Strict  as WS
 -- Do not be put off by the use of @UndecidableInstances@, it is safe
 -- here.
 --
--- @since unreleased
+-- @since 1.7.0.0
 class ( Monad m
       , MonadCatch m, MonadThrow m, MonadMask m
       , MonadSTM (STM m)
@@ -276,7 +276,7 @@ class ( Monad m
   -- 'isCurrentThreadBound' will always return 'False' and both
   -- 'forkOS' and 'runInBoundThread' will fail.
   --
-  -- @since unreleased
+  -- @since 1.7.0.0
   supportsBoundThreads :: m Bool
 
   -- | Returns 'True' if the calling thread is bound, that is, if it

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                concurrency
-version:             1.6.2.0
+version:             1.7.0.0
 synopsis:            Typeclasses, functions, and data types for concurrency and STM.
 
 description:
@@ -19,7 +19,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Michael Walker
 maintainer:          mike@barrucadu.co.uk
-copyright:           (c) 2016--2017 Michael Walker
+copyright:           (c) 2016--2019 Michael Walker
 category:            Concurrency
 build-type:          Simple
 extra-source-files:  README.markdown CHANGELOG.rst
@@ -32,7 +32,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      concurrency-1.6.2.0
+  tag:      concurrency-1.7.0.0
 
 library
   exposed-modules:     Control.Monad.Conc.Class

--- a/dejafu-tests/dejafu-tests.cabal
+++ b/dejafu-tests/dejafu-tests.cabal
@@ -23,13 +23,14 @@ library
 
                      , Integration
                      , Integration.Async
-                     , Integration.SingleThreaded
-                     , Integration.MultiThreaded
-                     , Integration.Refinement
                      , Integration.Litmus
+                     , Integration.MonadDejaFu
+                     , Integration.MultiThreaded
+                     , Integration.Names
+                     , Integration.Refinement
                      , Integration.Regressions
                      , Integration.SCT
-                     , Integration.Names
+                     , Integration.SingleThreaded
 
                      , Examples
                      , Examples.AutoUpdate

--- a/dejafu-tests/lib/Integration.hs
+++ b/dejafu-tests/lib/Integration.hs
@@ -4,6 +4,7 @@ import           Test.Tasty.Options         (OptionDescription)
 
 import qualified Integration.Async          as A
 import qualified Integration.Litmus         as L
+import qualified Integration.MonadDejaFu    as MD
 import qualified Integration.MultiThreaded  as M
 import qualified Integration.Names          as N
 import qualified Integration.Refinement     as R
@@ -19,6 +20,7 @@ tests =
   [ testGroup "Async"          A.tests
   , testGroup "Litmus"         L.tests
   , testGroup "MultiThreaded"  M.tests
+  , testGroup "MonadDejaFu"    MD.tests
   , testGroup "Names"          N.tests
   , testGroup "Refinement"     R.tests
   , testGroup "Regressions"    G.tests

--- a/dejafu-tests/lib/Integration/MonadDejaFu.hs
+++ b/dejafu-tests/lib/Integration/MonadDejaFu.hs
@@ -1,0 +1,66 @@
+module Integration.MonadDejaFu where
+
+import qualified Control.Concurrent.Classy as C
+
+import           Control.Monad.Catch.Pure  (runCatchT)
+import           Control.Monad.ST          (runST)
+import           Test.DejaFu.Conc          (Condition(..), Program,
+                                            roundRobinSched, runConcurrent)
+import           Test.DejaFu.Settings      (defaultMemType)
+import           Test.DejaFu.Types         (MonadDejaFu)
+import qualified Test.Tasty.HUnit          as TH
+
+import           Common
+
+tests :: [TestTree]
+tests =
+  [ testGroup "IO" ioTests
+  , testGroup "ST" stTests
+  ]
+
+--------------------------------------------------------------------------------
+
+ioTests :: [TestTree]
+ioTests = toTestList
+  [ TH.testCase "Supports bound threads" $
+      let res = single C.supportsBoundThreads
+      in TH.assertEqual "" (Right True) =<< res
+
+  , TH.testCase "Main thread is bound" $
+      let res = single C.isCurrentThreadBound
+      in TH.assertEqual "" (Right True) =<< res
+
+  , TH.testCase "Can fork bound threads" $
+      let res = single $ do
+            _ <- C.forkOS (pure ())
+            pure True
+      in TH.assertEqual "" (Right True) =<< res
+  ]
+
+--------------------------------------------------------------------------------
+
+stTests :: [TestTree]
+stTests = toTestList
+  [ TH.testCase "Doesn't support bound threads" $
+      let res = runST $ runCatchT $ single C.supportsBoundThreads
+      in TH.assertEqual "" (Right (Right False)) res
+
+  , TH.testCase "Main thread isn't bound" $
+      let res = runST $ runCatchT $ single C.isCurrentThreadBound
+      in TH.assertEqual "" (Right (Right False)) res
+
+  , TH.testCase "Can't fork bound threads" $
+      let res = runST $ runCatchT $ single $ do
+            _ <- C.forkOS (pure ())
+            pure True
+      in case res of
+           Right (Left (UncaughtException _)) -> pure ()
+           _ -> TH.assertFailure ("expected: Right (Left (UncaughtException _))\n but got: " ++ show res)
+  ]
+
+--------------------------------------------------------------------------------
+
+single :: MonadDejaFu n => Program pty n a -> n (Either Condition a)
+single program =
+  let fst3 (a, _, _) = a
+  in fst3 <$> runConcurrent roundRobinSched defaultMemType () program

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+2.1.0.0 (2019-03-24)
+--------------------
+
+* Git: :tag:`dejafu-2.1.0.0`
+* Hackage: :hackage:`dejafu-2.1.0.0`
 
 Added
 ~~~~~
@@ -57,6 +60,11 @@ Changed
         * ``resultsSetWithSettings``
         * ``runSCTWithSettings'``
         * ``resultsSetWithSettings'``
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The version bound on :hackage:`concurrency` is >=1.7 and <1.8.
 
 
 2.0.0.1 (2019-03-14)

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,6 +6,59 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+
+unreleased
+----------
+
+Added
+~~~~~
+
+* The ``Test.DejaFu.Types.MonadDejaFu`` typeclass, containing the
+  primitives needed to run a concurrent program.  There are instances
+  for:
+    * ``IO``, which is probably the ``MonadConc`` instance people used
+      previously, so there is no breaking change there.
+    * ``CatchT (ST t)``, meaning that concurrent programs can be run
+      without ``IO`` once more.
+
+* Thread action constructors for ``MonadConc``
+  ``supportsBoundThreads`` function:
+    * ``Test.DejaFu.Types.ThreadAction``, ``SupportsBoundThreads``
+    * ``Test.DejaFu.Types.Lookahead``, ``WillSupportsBoundThreads``
+
+Changed
+~~~~~~~
+
+* Many functions which had a ``MonadConc`` constraint now have a
+  ``MonadDejaFu`` constraint:
+    * In ``Test.DejaFu``
+        * ``autocheck``
+        * ``autocheckWay``
+        * ``autocheckWithSettings``
+        * ``dejafu``
+        * ``dejafuWay``
+        * ``dejafuWithSettings``
+        * ``dejafus``
+        * ``dejafusWay``
+        * ``dejafusWithSettings``
+        * ``runTest``
+        * ``runTestWay``
+        * ``runTestWithSettings``
+    * In ``Test.DejaFu.Conc``
+        * ``runConcurrent``
+        * ``recordSnapshot``
+        * ``runSnapshot``
+    * In ``Test.DejaFu.SCT``
+        * ``runSCT``
+        * ``resultsSet``
+        * ``runSCT'``
+        * ``resultsSet'``
+        * ``runSCTWithSettings``
+        * ``resultsSetWithSettings``
+        * ``runSCTWithSettings'``
+        * ``resultsSetWithSettings'``
+
+
 2.0.0.1 (2019-03-14)
 --------------------
 

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -371,7 +371,7 @@ let relaxed = do
 --     "world" S0----S2--S0--
 -- False
 --
--- @since unreleased
+-- @since 2.1.0.0
 autocheck :: (MonadDejaFu n, MonadIO n, Eq a, Show a)
   => Program pty n a
   -- ^ The computation to test.
@@ -403,7 +403,7 @@ autocheck = autocheckWithSettings defaultSettings
 --     (True,False) S0---------S2----S1----S0---
 -- False
 --
--- @since unreleased
+-- @since 2.1.0.0
 autocheckWay :: (MonadDejaFu n, MonadIO n, Eq a, Show a)
   => Way
   -- ^ How to run the concurrent program.
@@ -438,7 +438,7 @@ autocheckWay way = autocheckWithSettings . fromWayAndMemType way
 --     (True,False) S0---------S2----S1----S0---
 -- False
 --
--- @since unreleased
+-- @since 2.1.0.0
 autocheckWithSettings :: (MonadDejaFu n, MonadIO n, Eq a, Show a)
   => Settings n a
   -- ^ The SCT settings.
@@ -464,7 +464,7 @@ autocheckWithSettings settings = dejafusWithSettings settings
 --     "world" S0----S2--S0--
 -- False
 --
--- @since unreleased
+-- @since 2.1.0.0
 dejafu :: (MonadDejaFu n, MonadIO n, Show b)
   => String
   -- ^ The name of the test.
@@ -494,7 +494,7 @@ dejafu = dejafuWithSettings defaultSettings
 --     "world" S0----S2--S1-S0--
 -- False
 --
--- @since unreleased
+-- @since 2.1.0.0
 dejafuWay :: (MonadDejaFu n, MonadIO n, Show b)
   => Way
   -- ^ How to run the concurrent program.
@@ -520,7 +520,7 @@ dejafuWay way = dejafuWithSettings . fromWayAndMemType way
 --     "world" S0----S2--S1-S0--
 -- False
 --
--- @since unreleased
+-- @since 2.1.0.0
 dejafuWithSettings :: (MonadDejaFu n, MonadIO n, Show b)
   => Settings n a
   -- ^ The SCT settings.
@@ -545,7 +545,7 @@ dejafuWithSettings settings name test =
 -- [pass] B
 -- False
 --
--- @since unreleased
+-- @since 2.1.0.0
 dejafus :: (MonadDejaFu n, MonadIO n, Show b)
   => [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
@@ -567,7 +567,7 @@ dejafus = dejafusWithSettings defaultSettings
 -- [pass] B
 -- False
 --
--- @since unreleased
+-- @since 2.1.0.0
 dejafusWay :: (MonadDejaFu n, MonadIO n, Show b)
   => Way
   -- ^ How to run the concurrent program.
@@ -592,7 +592,7 @@ dejafusWay way = dejafusWithSettings . fromWayAndMemType way
 -- [pass] B
 -- False
 --
--- @since unreleased
+-- @since 2.1.0.0
 dejafusWithSettings :: (MonadDejaFu n, MonadIO n, Show b)
   => Settings n a
   -- ^ The SCT settings.
@@ -668,7 +668,7 @@ instance Foldable Result where
 -- found, is unspecified and may change between releases.  This may
 -- affect which failing traces are reported, when there is a failure.
 --
--- @since unreleased
+-- @since 2.1.0.0
 runTest :: MonadDejaFu n
   => ProPredicate a b
   -- ^ The predicate to check
@@ -684,7 +684,7 @@ runTest = runTestWithSettings defaultSettings
 -- found, is unspecified and may change between releases.  This may
 -- affect which failing traces are reported, when there is a failure.
 --
--- @since unreleased
+-- @since 2.1.0.0
 runTestWay :: MonadDejaFu n
   => Way
   -- ^ How to run the concurrent program.
@@ -703,7 +703,7 @@ runTestWay way = runTestWithSettings . fromWayAndMemType way
 -- found, is unspecified and may change between releases.  This may
 -- affect which failing traces are reported, when there is a failure.
 --
--- @since unreleased
+-- @since 2.1.0.0
 runTestWithSettings :: MonadDejaFu n
   => Settings n a
   -- ^ The SCT settings.

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -313,18 +313,16 @@ interference we have provided: the left term never empties a full
   , inspectTVar
 ) where
 
-import           Control.Arrow            (first)
-import           Control.DeepSeq          (NFData(..))
-import           Control.Monad            (unless, when)
-import           Control.Monad.Conc.Class (MonadConc)
-import           Control.Monad.IO.Class   (MonadIO(..))
-import           Data.Either              (isLeft)
-import           Data.Function            (on)
-import           Data.List                (intercalate, intersperse, partition)
-import           Data.Maybe               (catMaybes, isJust, isNothing,
-                                           mapMaybe)
-import           Data.Profunctor          (Profunctor(..))
-import           System.Environment       (lookupEnv)
+import           Control.Arrow          (first)
+import           Control.DeepSeq        (NFData(..))
+import           Control.Monad          (unless, when)
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Data.Either            (isLeft)
+import           Data.Function          (on)
+import           Data.List              (intercalate, intersperse, partition)
+import           Data.Maybe             (catMaybes, isJust, isNothing, mapMaybe)
+import           Data.Profunctor        (Profunctor(..))
+import           System.Environment     (lookupEnv)
 
 import           Test.DejaFu.Conc
 import           Test.DejaFu.Internal
@@ -373,8 +371,8 @@ let relaxed = do
 --     "world" S0----S2--S0--
 -- False
 --
--- @since 2.0.0.0
-autocheck :: (MonadConc n, MonadIO n, Eq a, Show a)
+-- @since unreleased
+autocheck :: (MonadDejaFu n, MonadIO n, Eq a, Show a)
   => Program pty n a
   -- ^ The computation to test.
   -> n Bool
@@ -405,8 +403,8 @@ autocheck = autocheckWithSettings defaultSettings
 --     (True,False) S0---------S2----S1----S0---
 -- False
 --
--- @since 2.0.0.0
-autocheckWay :: (MonadConc n, MonadIO n, Eq a, Show a)
+-- @since unreleased
+autocheckWay :: (MonadDejaFu n, MonadIO n, Eq a, Show a)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
@@ -440,8 +438,8 @@ autocheckWay way = autocheckWithSettings . fromWayAndMemType way
 --     (True,False) S0---------S2----S1----S0---
 -- False
 --
--- @since 2.0.0.0
-autocheckWithSettings :: (MonadConc n, MonadIO n, Eq a, Show a)
+-- @since unreleased
+autocheckWithSettings :: (MonadDejaFu n, MonadIO n, Eq a, Show a)
   => Settings n a
   -- ^ The SCT settings.
   -> Program pty n a
@@ -466,8 +464,8 @@ autocheckWithSettings settings = dejafusWithSettings settings
 --     "world" S0----S2--S0--
 -- False
 --
--- @since 2.0.0.0
-dejafu :: (MonadConc n, MonadIO n, Show b)
+-- @since unreleased
+dejafu :: (MonadDejaFu n, MonadIO n, Show b)
   => String
   -- ^ The name of the test.
   -> ProPredicate a b
@@ -496,8 +494,8 @@ dejafu = dejafuWithSettings defaultSettings
 --     "world" S0----S2--S1-S0--
 -- False
 --
--- @since 2.0.0.0
-dejafuWay :: (MonadConc n, MonadIO n, Show b)
+-- @since unreleased
+dejafuWay :: (MonadDejaFu n, MonadIO n, Show b)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
@@ -522,8 +520,8 @@ dejafuWay way = dejafuWithSettings . fromWayAndMemType way
 --     "world" S0----S2--S1-S0--
 -- False
 --
--- @since 2.0.0.0
-dejafuWithSettings :: (MonadConc n, MonadIO n, Show b)
+-- @since unreleased
+dejafuWithSettings :: (MonadDejaFu n, MonadIO n, Show b)
   => Settings n a
   -- ^ The SCT settings.
   -> String
@@ -547,8 +545,8 @@ dejafuWithSettings settings name test =
 -- [pass] B
 -- False
 --
--- @since 2.0.0.0
-dejafus :: (MonadConc n, MonadIO n, Show b)
+-- @since unreleased
+dejafus :: (MonadDejaFu n, MonadIO n, Show b)
   => [(String, ProPredicate a b)]
   -- ^ The list of predicates (with names) to check.
   -> Program pty n a
@@ -569,8 +567,8 @@ dejafus = dejafusWithSettings defaultSettings
 -- [pass] B
 -- False
 --
--- @since 2.0.0.0
-dejafusWay :: (MonadConc n, MonadIO n, Show b)
+-- @since unreleased
+dejafusWay :: (MonadDejaFu n, MonadIO n, Show b)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
@@ -594,8 +592,8 @@ dejafusWay way = dejafusWithSettings . fromWayAndMemType way
 -- [pass] B
 -- False
 --
--- @since 2.0.0.0
-dejafusWithSettings :: (MonadConc n, MonadIO n, Show b)
+-- @since unreleased
+dejafusWithSettings :: (MonadDejaFu n, MonadIO n, Show b)
   => Settings n a
   -- ^ The SCT settings.
   -> [(String, ProPredicate a b)]
@@ -670,8 +668,8 @@ instance Foldable Result where
 -- found, is unspecified and may change between releases.  This may
 -- affect which failing traces are reported, when there is a failure.
 --
--- @since 2.0.0.0
-runTest :: MonadConc n
+-- @since unreleased
+runTest :: MonadDejaFu n
   => ProPredicate a b
   -- ^ The predicate to check
   -> Program pty n a
@@ -686,8 +684,8 @@ runTest = runTestWithSettings defaultSettings
 -- found, is unspecified and may change between releases.  This may
 -- affect which failing traces are reported, when there is a failure.
 --
--- @since 2.0.0.0
-runTestWay :: MonadConc n
+-- @since unreleased
+runTestWay :: MonadDejaFu n
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
@@ -705,8 +703,8 @@ runTestWay way = runTestWithSettings . fromWayAndMemType way
 -- found, is unspecified and may change between releases.  This may
 -- affect which failing traces are reported, when there is a failure.
 --
--- @since 2.0.0.0
-runTestWithSettings :: MonadConc n
+-- @since unreleased
+runTestWithSettings :: MonadDejaFu n
   => Settings n a
   -- ^ The SCT settings.
   -> ProPredicate a b

--- a/dejafu/Test/DejaFu/Conc/Internal.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal.hs
@@ -297,7 +297,7 @@ stepThread _ _ _ _ tid (AForkOS n a b) = \ctx@Context{..} -> case forkBoundThrea
          , const (pure ())
          )
   Nothing ->
-    fatal "tried to fork bound thread but the underlying monad doesn't support them"
+    stepThrow Throw tid (MonadFailException "dejafu is running with bound threads disabled - do not use forkOS") ctx
 
 -- check if we support bound threads
 stepThread _ _ _ _ tid (ASupportsBoundThreads c) = \ctx@Context{..} -> do

--- a/dejafu/Test/DejaFu/Conc/Internal.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal.hs
@@ -3,14 +3,15 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
 -- Module      : Test.DejaFu.Conc.Internal
--- Copyright   : (c) 2016--2018 Michael Walker
+-- Copyright   : (c) 2016--2019 Michael Walker
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
--- Portability : FlexibleContexts, LambdaCase, MultiWayIf, RankNTypes, RecordWildCards
+-- Portability : FlexibleContexts, LambdaCase, MultiWayIf, RankNTypes, RecordWildCards, ScopedTypeVariables
 --
 -- Concurrent monads with a fixed scheduler: internal types and
 -- functions. This module is NOT considered to form part of the public
@@ -21,7 +22,6 @@ import           Control.Exception                   (Exception,
                                                       MaskingState(..),
                                                       toException)
 import qualified Control.Monad.Catch                 as E
-import qualified Control.Monad.Conc.Class            as C
 import           Data.Foldable                       (foldrM)
 import           Data.Functor                        (void)
 import           Data.List                           (nub, partition, sortOn)
@@ -50,7 +50,7 @@ type SeqTrace
 -- | The result of running a concurrent program.
 data CResult n g a = CResult
   { finalContext :: Context n g
-  , finalRef :: C.IORef n (Maybe (Either Condition a))
+  , finalRef :: Ref n (Maybe (Either Condition a))
   , finalRestore :: Threads n -> n ()
   -- ^ Meaningless if this result doesn't come from a snapshotting
   -- execution.
@@ -61,7 +61,7 @@ data CResult n g a = CResult
 -- | Run a concurrent computation with a given 'Scheduler' and initial
 -- state, returning a Condition reason on error. Also returned is the
 -- final state of the scheduler, and an execution trace.
-runConcurrency :: (C.MonadConc n, HasCallStack)
+runConcurrency :: (MonadDejaFu n, HasCallStack)
   => [Invariant n ()]
   -> Bool
   -> Scheduler g
@@ -83,14 +83,15 @@ runConcurrency invariants forSnapshot sched memtype g idsrc caps ma = do
                     }
   (c, ref) <- runRefCont AStop (Just . Right) (runModelConc ma)
   let threads0 = launch' Unmasked initialThread (const c) (cThreads ctx)
-  sbt <- C.supportsBoundThreads
-  threads <- (if sbt then makeBound initialThread else pure) threads0
+  threads <- case forkBoundThread of
+    Just fbt -> makeBound fbt initialThread threads0
+    Nothing  -> pure threads0
   res <- runThreads forSnapshot sched memtype ref ctx { cThreads = threads }
   killAllThreads (finalContext res)
   pure res
 
 -- | Like 'runConcurrency' but starts from a snapshot.
-runConcurrencyWithSnapshot :: (C.MonadConc n, HasCallStack)
+runConcurrencyWithSnapshot :: (MonadDejaFu n, HasCallStack)
   => Scheduler g
   -> MemType
   -> Context n g
@@ -101,17 +102,19 @@ runConcurrencyWithSnapshot sched memtype ctx restore ma = do
   (c, ref) <- runRefCont AStop (Just . Right) (runModelConc ma)
   let threads0 = M.delete initialThread (cThreads ctx)
   let threads1 = launch' Unmasked initialThread (const c) threads0
-  let boundThreads = M.filter (isJust . _bound) threads1
-  sbt <- C.supportsBoundThreads
-  threads2 <- (if sbt then makeBound initialThread else pure) threads1
-  threads3 <- foldrM makeBound threads2 (M.keys boundThreads)
-  restore threads3
-  res <- runThreads False sched memtype ref ctx { cThreads = threads3 }
+  threads <- case forkBoundThread of
+    Just fbt -> do
+      let boundThreads = M.filter (isJust . _bound) threads1
+      threads' <- makeBound fbt initialThread threads1
+      foldrM (makeBound fbt) threads' (M.keys boundThreads)
+    Nothing -> pure threads1
+  restore threads
+  res <- runThreads False sched memtype ref ctx { cThreads = threads }
   killAllThreads (finalContext res)
   pure res
 
 -- | Kill the remaining threads
-killAllThreads :: (C.MonadConc n, HasCallStack) => Context n g -> n ()
+killAllThreads :: (MonadDejaFu n, HasCallStack) => Context n g -> n ()
 killAllThreads ctx =
   let finalThreads = cThreads ctx
   in mapM_ (`kill` finalThreads) (M.keys finalThreads)
@@ -132,17 +135,17 @@ data Context n g = Context
   }
 
 -- | Run a collection of threads, until there are no threads left.
-runThreads :: (C.MonadConc n, HasCallStack)
+runThreads :: (MonadDejaFu n, HasCallStack)
   => Bool
   -> Scheduler g
   -> MemType
-  -> C.IORef n (Maybe (Either Condition a))
+  -> Ref n (Maybe (Either Condition a))
   -> Context n g
   -> n (CResult n g a)
 runThreads forSnapshot sched memtype ref = schedule (const $ pure ()) Seq.empty Nothing where
   -- signal failure & terminate
   die reason finalR finalT finalD finalC = do
-    C.writeIORef ref (Just $ Left reason)
+    writeRef ref (Just $ Left reason)
     stop finalR finalT finalD finalC
 
   -- just terminate; 'ref' must have been written to before calling
@@ -258,7 +261,7 @@ data What n g
 --
 -- Note: the returned snapshot action will definitely not do the right
 -- thing with relaxed memory.
-stepThread :: (C.MonadConc n, HasCallStack)
+stepThread :: forall n g. (MonadDejaFu n, HasCallStack)
   => Bool
   -- ^ Should we record a snapshot?
   -> Bool
@@ -284,18 +287,21 @@ stepThread _ _ _ _ tid (AFork n a b) = \ctx@Context{..} -> pure $
      )
 
 -- start a new bound thread, assigning it the next 'ThreadId'
-stepThread _ _ _ _ tid (AForkOS n a b) = \ctx@Context{..} -> do
-  let (idSource', newtid) = nextTId n cIdSource
-  let threads' = launch tid newtid a cThreads
-  threads'' <- makeBound newtid threads'
-  pure ( Succeeded ctx { cThreads = goto (b newtid) tid threads'', cIdSource = idSource' }
-       , ForkOS newtid
-       , const (pure ())
-       )
+stepThread _ _ _ _ tid (AForkOS n a b) = \ctx@Context{..} -> case forkBoundThread of
+  Just fbt -> do
+    let (idSource', newtid) = nextTId n cIdSource
+    let threads' = launch tid newtid a cThreads
+    threads'' <- makeBound fbt newtid threads'
+    pure ( Succeeded ctx { cThreads = goto (b newtid) tid threads'', cIdSource = idSource' }
+         , ForkOS newtid
+         , const (pure ())
+         )
+  Nothing ->
+    fatal "tried to fork bound thread but the underlying monad doesn't support them"
 
 -- check if we support bound threads
 stepThread _ _ _ _ tid (ASupportsBoundThreads c) = \ctx@Context{..} -> do
-  sbt <- C.supportsBoundThreads
+  let sbt = isJust (forkBoundThread :: Maybe (n (BoundThread n ())))
   pure ( Succeeded ctx { cThreads = goto (c sbt) tid cThreads }
        , SupportsBoundThreads sbt
        , const (pure ())
@@ -347,11 +353,11 @@ stepThread _ _ _ _ tid (ADelay n c) = \ctx@Context{..} ->
 -- create a new @MVar@, using the next 'MVarId'.
 stepThread _ _ _ _ tid (ANewMVar n c) = \ctx@Context{..} -> do
   let (idSource', newmvid) = nextMVId n cIdSource
-  ref <- C.newIORef Nothing
+  ref <- newRef Nothing
   let mvar = ModelMVar newmvid ref
   pure ( Succeeded ctx { cThreads = goto (c mvar) tid cThreads, cIdSource = idSource' }
        , NewMVar newmvid
-       , const (C.writeIORef ref Nothing)
+       , const (writeRef ref Nothing)
        )
 
 -- put a value into a @MVar@, blocking the thread until it's empty.
@@ -408,11 +414,11 @@ stepThread _ _ _ _ tid (ATryTakeMVar mvar@ModelMVar{..} c) = synchronised $ \ctx
 stepThread _ _ _ _  tid (ANewIORef n a c) = \ctx@Context{..} -> do
   let (idSource', newiorid) = nextIORId n cIdSource
   let val = (M.empty, 0, a)
-  ioref <- C.newIORef val
+  ioref <- newRef val
   let ref = ModelIORef newiorid ioref
   pure ( Succeeded ctx { cThreads = goto (c ref) tid cThreads, cIdSource = idSource' }
        , NewIORef newiorid
-       , const (C.writeIORef ioref val)
+       , const (writeRef ioref val)
        )
 
 -- read from a @IORef@.
@@ -619,7 +625,7 @@ stepThread _ _ _ _ tid (ANewInvariant inv c) = \ctx@Context{..} ->
 
 -- | Handle an exception being thrown from an @AAtom@, @AThrow@, or
 -- @AThrowTo@.
-stepThrow :: (C.MonadConc n, Exception e)
+stepThrow :: (MonadDejaFu n, Exception e)
   => (Bool -> ThreadAction)
   -- ^ Action to include in the trace.
   -> ThreadId
@@ -651,7 +657,7 @@ stepThrow act tid e ctx@Context{..} = case propagate some tid cThreads of
     some = toException e
 
 -- | Helper for actions impose a write barrier.
-synchronised :: C.MonadConc n
+synchronised :: MonadDejaFu n
   => (Context n g -> n x)
   -- ^ Action to run after the write barrier.
   -> Context n g
@@ -684,7 +690,7 @@ unblockInvariants act ic = InvariantContext active blocked where
 
 -- | Check all active invariants, returning an arbitrary failure if
 -- multiple ones fail.
-checkInvariants :: C.MonadConc n
+checkInvariants :: MonadDejaFu n
   => InvariantContext n
   -> n (Either E.SomeException (InvariantContext n))
 checkInvariants ic = go (icActive ic) >>= \case
@@ -697,7 +703,7 @@ checkInvariants ic = go (icActive ic) >>= \case
     go [] = pure (Right [])
 
 -- | Check an invariant.
-checkInvariant :: C.MonadConc n
+checkInvariant :: MonadDejaFu n
   => Invariant n a
   -> n (Either E.SomeException ([IORefId], [MVarId], [TVarId]))
 checkInvariant inv = doInvariant inv >>= \case
@@ -705,13 +711,13 @@ checkInvariant inv = doInvariant inv >>= \case
   (Left exc, _, _, _) -> pure (Left exc)
 
 -- | Run an invariant (more primitive)
-doInvariant :: C.MonadConc n
+doInvariant :: MonadDejaFu n
   => Invariant n a
   -> n (Either E.SomeException a, [IORefId], [MVarId], [TVarId])
 doInvariant inv = do
     (c, ref) <- runRefCont IStop (Just . Right) (runInvariant inv)
     (iorefs, mvars, tvars) <- go ref c [] [] []
-    val <- C.readIORef ref
+    val <- readRef ref
     pure (efromJust val, nub iorefs, nub mvars, nub tvars)
   where
     go ref act iorefs mvars tvars = do
@@ -725,21 +731,21 @@ doInvariant inv = do
         Right Nothing ->
           pure (newIORefs, newMVars, newTVars)
         Left exc -> do
-          C.writeIORef ref (Just (Left exc))
+          writeRef ref (Just (Left exc))
           pure (newIORefs, newMVars, newTVars)
 
 -- | Run an invariant for one step
-stepInvariant :: C.MonadConc n
+stepInvariant :: MonadDejaFu n
   => IAction n
   -> n (Either E.SomeException (Maybe (IAction n)), [IORefId], [MVarId], [TVarId])
 stepInvariant (IInspectIORef ioref@ModelIORef{..} k) = do
   a <- readIORefGlobal ioref
   pure (Right (Just (k a)), [iorefId], [], [])
 stepInvariant (IInspectMVar ModelMVar{..} k) = do
-  a <- C.readIORef mvarRef
+  a <- readRef mvarRef
   pure (Right (Just (k a)), [], [mvarId], [])
 stepInvariant (IInspectTVar ModelTVar{..} k) = do
-  a <- C.readIORef tvarRef
+  a <- readRef tvarRef
   pure (Right (Just (k a)), [], [], [tvarId])
 stepInvariant (ICatch h nx k) = doInvariant nx >>= \case
   (Right a, iorefs, mvars, tvars) ->

--- a/dejafu/Test/DejaFu/Conc/Internal/Common.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Common.hs
@@ -136,6 +136,8 @@ data ModelTicket a = ModelTicket
 data Action n =
     AFork   String ((forall b. ModelConc n b -> ModelConc n b) -> Action n) (ThreadId -> Action n)
   | AForkOS String ((forall b. ModelConc n b -> ModelConc n b) -> Action n) (ThreadId -> Action n)
+
+  | ASupportsBoundThreads (Bool -> Action n)
   | AIsBound (Bool -> Action n)
   | AMyTId (ThreadId -> Action n)
 
@@ -182,6 +184,7 @@ data Action n =
 lookahead :: Action n -> Lookahead
 lookahead (AFork _ _ _) = WillFork
 lookahead (AForkOS _ _ _) = WillForkOS
+lookahead (ASupportsBoundThreads _) = WillSupportsBoundThreads
 lookahead (AIsBound _) = WillIsCurrentThreadBound
 lookahead (AMyTId _) = WillMyThreadId
 lookahead (AGetNumCapabilities _) = WillGetNumCapabilities

--- a/dejafu/Test/DejaFu/Conc/Internal/Common.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Common.hs
@@ -17,7 +17,6 @@ module Test.DejaFu.Conc.Internal.Common where
 
 import           Control.Exception             (Exception, MaskingState(..))
 import           Control.Monad.Catch           (MonadCatch(..), MonadThrow(..))
-import qualified Control.Monad.Conc.Class      as C
 import qualified Control.Monad.Fail            as Fail
 import           Data.Map.Strict               (Map)
 
@@ -106,7 +105,7 @@ instance (pty ~ Basic) => Fail.MonadFail (Program pty n) where
 -- @Maybe@ value.
 data ModelMVar n a = ModelMVar
   { mvarId  :: MVarId
-  , mvarRef :: C.IORef n (Maybe a)
+  , mvarRef :: Ref n (Maybe a)
   }
 
 -- | A @IORef@ is modelled as a unique ID and a reference holding
@@ -114,7 +113,7 @@ data ModelMVar n a = ModelMVar
 -- committed value.
 data ModelIORef n a = ModelIORef
   { iorefId  :: IORefId
-  , iorefRef :: C.IORef n (Map ThreadId a, Integer, a)
+  , iorefRef :: Ref n (Map ThreadId a, Integer, a)
   }
 
 -- | A @Ticket@ is modelled as the ID of the @ModelIORef@ it came from,

--- a/dejafu/Test/DejaFu/Conc/Internal/Program.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Program.hs
@@ -170,7 +170,7 @@ instance (pty ~ Basic, Monad n) => C.MonadConc (Program pty n) where
 -- nonexistent thread. In either of those cases, the computation will
 -- be halted.
 --
--- @since unreleased
+-- @since 2.1.0.0
 runConcurrent :: MonadDejaFu n
   => Scheduler s
   -> MemType
@@ -250,7 +250,7 @@ runConcurrent sched memtype s ma = recordSnapshot ma >>= \case
 --   (liftIO . readIORef)
 -- @
 --
--- @since unreleased
+-- @since 2.1.0.0
 recordSnapshot
   :: MonadDejaFu n
   => Program pty n a
@@ -265,7 +265,7 @@ recordSnapshot WithSetupAndTeardown{..} =
 
 -- | Runs a program with snapshotted setup to completion.
 --
--- @since unreleased
+-- @since 2.1.0.0
 runSnapshot
   :: MonadDejaFu n
   => Scheduler s

--- a/dejafu/Test/DejaFu/Conc/Internal/Program.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Program.hs
@@ -92,15 +92,9 @@ instance (pty ~ Basic, Monad n) => C.MonadConc (Program pty n) where
 
   forkWithUnmaskN   n ma = ModelConc (AFork n (\umask -> runModelConc (ma umask) (\_ -> AStop (pure ()))))
   forkOnWithUnmaskN n _  = C.forkWithUnmaskN n
+  forkOSWithUnmaskN n ma = ModelConc (AForkOS n (\umask -> runModelConc (ma umask) (\_ -> AStop (pure ()))))
 
   supportsBoundThreads = ModelConc ASupportsBoundThreads
-
-  forkOSWithUnmaskN n ma = C.supportsBoundThreads >>= \case
-    True ->
-      ModelConc (AForkOS n (\umask -> runModelConc (ma umask) (\_ -> AStop (pure ()))))
-    False ->
-      fail "RTS doesn't support multiple OS threads (use ghc -threaded when linking)"
-
   isCurrentThreadBound = ModelConc AIsBound
 
   -- This implementation lies and returns 2 until a value is set. This

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -17,18 +17,17 @@
 -- library.
 module Test.DejaFu.Internal where
 
-import           Control.DeepSeq          (NFData(..))
-import           Control.Exception        (MaskingState(..))
-import qualified Control.Monad.Conc.Class as C
-import           Data.List.NonEmpty       (NonEmpty(..))
-import           Data.Map.Strict          (Map)
-import qualified Data.Map.Strict          as M
-import           Data.Maybe               (fromMaybe)
-import           Data.Set                 (Set)
-import qualified Data.Set                 as S
-import           GHC.Generics             (Generic)
-import           GHC.Stack                (HasCallStack, withFrozenCallStack)
-import           System.Random            (RandomGen)
+import           Control.DeepSeq    (NFData(..))
+import           Control.Exception  (MaskingState(..))
+import           Data.List.NonEmpty (NonEmpty(..))
+import           Data.Map.Strict    (Map)
+import qualified Data.Map.Strict    as M
+import           Data.Maybe         (fromMaybe)
+import           Data.Set           (Set)
+import qualified Data.Set           as S
+import           GHC.Generics       (Generic)
+import           GHC.Stack          (HasCallStack, withFrozenCallStack)
+import           System.Random      (RandomGen)
 
 import           Test.DejaFu.Types
 
@@ -450,12 +449,12 @@ fatal msg = withFrozenCallStack $ error ("(dejafu) " ++ msg)
 -- | Run with a continuation that writes its value into a reference,
 -- returning the computation and the reference.  Using the reference
 -- is non-blocking, it is up to you to ensure you wait sufficiently.
-runRefCont :: C.MonadConc n
+runRefCont :: MonadDejaFu n
   => (n () -> x)
   -> (a -> Maybe b)
   -> ((a -> x) -> x)
-  -> n (x, C.IORef n (Maybe b))
+  -> n (x, Ref n (Maybe b))
 runRefCont act f k = do
-  ref <- C.newIORef Nothing
-  let c = k (act . C.writeIORef ref . f)
+  ref <- newRef Nothing
+  let c = k (act . writeRef ref . f)
   pure (c, ref)

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -165,6 +165,7 @@ tvarsRead act = S.fromList $ case act of
 rewind :: ThreadAction -> Lookahead
 rewind (Fork _) = WillFork
 rewind (ForkOS _) = WillForkOS
+rewind (SupportsBoundThreads _) = WillSupportsBoundThreads
 rewind (IsCurrentThreadBound _) = WillIsCurrentThreadBound
 rewind MyThreadId = WillMyThreadId
 rewind (GetNumCapabilities _) = WillGetNumCapabilities

--- a/dejafu/Test/DejaFu/SCT.hs
+++ b/dejafu/Test/DejaFu/SCT.hs
@@ -48,7 +48,7 @@ import           Test.DejaFu.Utils
 -- The exact executions tried, and the order in which results are
 -- found, is unspecified and may change between releases.
 --
--- @since unreleased
+-- @since 2.1.0.0
 runSCT :: MonadDejaFu n
   => Way
   -- ^ How to run the concurrent program.
@@ -61,7 +61,7 @@ runSCT way = runSCTWithSettings . fromWayAndMemType way
 
 -- | Return the set of results of a concurrent program.
 --
--- @since unreleased
+-- @since 2.1.0.0
 resultsSet :: (MonadDejaFu n, Ord a)
   => Way
   -- ^ How to run the concurrent program.
@@ -80,7 +80,7 @@ resultsSet way = resultsSetWithSettings . fromWayAndMemType way
 -- The exact executions tried, and the order in which results are
 -- found, is unspecified and may change between releases.
 --
--- @since unreleased
+-- @since 2.1.0.0
 runSCT' :: (MonadDejaFu n, NFData a)
   => Way
   -- ^ How to run the concurrent program.
@@ -96,7 +96,7 @@ runSCT' way = runSCTWithSettings' . fromWayAndMemType way
 -- Demanding the result of this will force it to normal form, which
 -- may be more efficient in some situations.
 --
--- @since unreleased
+-- @since 2.1.0.0
 resultsSet' :: (MonadDejaFu n, Ord a, NFData a)
   => Way
   -- ^ How to run the concurrent program.
@@ -115,7 +115,7 @@ resultsSet' way = resultsSetWithSettings' . fromWayAndMemType way
 -- The exact executions tried, and the order in which results are
 -- found, is unspecified and may change between releases.
 --
--- @since unreleased
+-- @since 2.1.0.0
 runSCTWithSettings :: MonadDejaFu n
   => Settings n a
   -- ^ The SCT settings.
@@ -156,7 +156,7 @@ runSCTWithSettings settings conc = case _way settings of
 
 -- | A variant of 'resultsSet' which takes a 'Settings' record.
 --
--- @since unreleased
+-- @since 2.1.0.0
 resultsSetWithSettings :: (MonadDejaFu n, Ord a)
   => Settings n a
   -- ^ The SCT settings.
@@ -175,7 +175,7 @@ resultsSetWithSettings settings conc =
 -- The exact executions tried, and the order in which results are
 -- found, is unspecified and may change between releases.
 --
--- @since unreleased
+-- @since 2.1.0.0
 runSCTWithSettings' :: (MonadDejaFu n, NFData a)
   => Settings n a
   -- ^ The SCT settings.
@@ -191,7 +191,7 @@ runSCTWithSettings' settings conc = do
 -- Demanding the result of this will force it to normal form, which
 -- may be more efficient in some situations.
 --
--- @since unreleased
+-- @since 2.1.0.0
 resultsSetWithSettings' :: (MonadDejaFu n, Ord a, NFData a)
   => Settings n a
   -- ^ The SCT settings.

--- a/dejafu/Test/DejaFu/SCT.hs
+++ b/dejafu/Test/DejaFu/SCT.hs
@@ -26,7 +26,6 @@ module Test.DejaFu.SCT
 
 import           Control.Applicative               ((<|>))
 import           Control.DeepSeq                   (NFData(..), force)
-import           Control.Monad.Conc.Class          (MonadConc)
 import           Data.List                         (foldl')
 import qualified Data.Map.Strict                   as M
 import           Data.Maybe                        (fromMaybe)
@@ -51,8 +50,8 @@ import           Test.DejaFu.Utils
 -- The exact executions tried, and the order in which results are
 -- found, is unspecified and may change between releases.
 --
--- @since 2.0.0.0
-runSCT :: MonadConc n
+-- @since unreleased
+runSCT :: MonadDejaFu n
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
@@ -64,8 +63,8 @@ runSCT way = runSCTWithSettings . fromWayAndMemType way
 
 -- | Return the set of results of a concurrent program.
 --
--- @since 2.0.0.0
-resultsSet :: (MonadConc n, Ord a)
+-- @since unreleased
+resultsSet :: (MonadDejaFu n, Ord a)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
@@ -83,8 +82,8 @@ resultsSet way = resultsSetWithSettings . fromWayAndMemType way
 -- The exact executions tried, and the order in which results are
 -- found, is unspecified and may change between releases.
 --
--- @since 2.0.0.0
-runSCT' :: (MonadConc n, NFData a)
+-- @since unreleased
+runSCT' :: (MonadDejaFu n, NFData a)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
@@ -99,8 +98,8 @@ runSCT' way = runSCTWithSettings' . fromWayAndMemType way
 -- Demanding the result of this will force it to normal form, which
 -- may be more efficient in some situations.
 --
--- @since 2.0.0.0
-resultsSet' :: (MonadConc n, Ord a, NFData a)
+-- @since unreleased
+resultsSet' :: (MonadDejaFu n, Ord a, NFData a)
   => Way
   -- ^ How to run the concurrent program.
   -> MemType
@@ -118,8 +117,8 @@ resultsSet' way = resultsSetWithSettings' . fromWayAndMemType way
 -- The exact executions tried, and the order in which results are
 -- found, is unspecified and may change between releases.
 --
--- @since 2.0.0.0
-runSCTWithSettings :: MonadConc n
+-- @since unreleased
+runSCTWithSettings :: MonadDejaFu n
   => Settings n a
   -- ^ The SCT settings.
   -> Program pty n a
@@ -159,8 +158,8 @@ runSCTWithSettings settings conc = case _way settings of
 
 -- | A variant of 'resultsSet' which takes a 'Settings' record.
 --
--- @since 2.0.0.0
-resultsSetWithSettings :: (MonadConc n, Ord a)
+-- @since unreleased
+resultsSetWithSettings :: (MonadDejaFu n, Ord a)
   => Settings n a
   -- ^ The SCT settings.
   -> Program pty n a
@@ -178,8 +177,8 @@ resultsSetWithSettings settings conc =
 -- The exact executions tried, and the order in which results are
 -- found, is unspecified and may change between releases.
 --
--- @since 2.0.0.0
-runSCTWithSettings' :: (MonadConc n, NFData a)
+-- @since unreleased
+runSCTWithSettings' :: (MonadDejaFu n, NFData a)
   => Settings n a
   -- ^ The SCT settings.
   -> Program pty n a
@@ -194,8 +193,8 @@ runSCTWithSettings' settings conc = do
 -- Demanding the result of this will force it to normal form, which
 -- may be more efficient in some situations.
 --
--- @since 2.0.0.0
-resultsSetWithSettings' :: (MonadConc n, Ord a, NFData a)
+-- @since unreleased
+resultsSetWithSettings' :: (MonadDejaFu n, Ord a, NFData a)
   => Settings n a
   -- ^ The SCT settings.
   -> Program pty n a

--- a/dejafu/Test/DejaFu/SCT.hs
+++ b/dejafu/Test/DejaFu/SCT.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
 -- |
 -- Module      : Test.DejaFu.SCT
 -- Copyright   : (c) 2015--2019 Michael Walker

--- a/dejafu/Test/DejaFu/SCT/Internal.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal.hs
@@ -5,7 +5,7 @@
 
 -- |
 -- Module      : Test.DejaFu.SCT.Internal
--- Copyright   : (c) 2018 Michael Walker
+-- Copyright   : (c) 2018--2019 Michael Walker
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
@@ -15,7 +15,6 @@
 -- considered to form part of the public interface of this library.
 module Test.DejaFu.SCT.Internal where
 
-import           Control.Monad.Conc.Class          (MonadConc)
 import           Data.Coerce                       (Coercible, coerce)
 import qualified Data.IntMap.Strict                as I
 import           Data.List                         (find, mapAccumL)
@@ -36,7 +35,7 @@ import           Test.DejaFu.Utils
 -- * Exploration
 
 -- | General-purpose SCT function.
-sct :: (MonadConc n, HasCallStack)
+sct :: (MonadDejaFu n, HasCallStack)
   => Settings n a
   -- ^ The SCT settings ('Way' is ignored)
   -> ([ThreadId] -> s)
@@ -79,7 +78,7 @@ sct settings s0 sfun srun conc = recordSnapshot conc >>= \case
     runSnap snap sched s = runSnapshot sched (_memtype settings) s snap
 
 -- | Like 'sct' but given a function to run the computation.
-sct' :: (MonadConc n, HasCallStack)
+sct' :: (MonadDejaFu n, HasCallStack)
   => Settings n a
   -- ^ The SCT settings ('Way' is ignored)
   -> ConcurrencyState
@@ -150,7 +149,7 @@ sct' settings cstate0 s0 sfun srun run nTId nCRId = go Nothing [] s0 where
 -- Unlike shrinking in randomised property-testing tools like
 -- QuickCheck or Hedgehog, we only run the test case /once/, at the
 -- end, rather than after every simplification step.
-simplifyExecution :: (MonadConc n, HasCallStack)
+simplifyExecution :: (MonadDejaFu n, HasCallStack)
   => Settings n a
   -- ^ The SCT settings ('Way' is ignored)
   -> ConcurrencyState
@@ -190,7 +189,7 @@ simplifyExecution settings cstate0 run nTId nCRId res trace
     p = either show debugShow
 
 -- | Replay an execution.
-replay :: MonadConc n
+replay :: MonadDejaFu n
   => (forall x. Scheduler x -> x -> n (Either Condition a, x, Trace))
   -- ^ Run the computation
   -> [(ThreadId, ThreadAction)]

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -51,7 +51,7 @@ import           GHC.Generics                         (Generic, V1)
 -- needs the ability to throw exceptions, as these are used to
 -- communicate 'Error's, so there is a 'MonadThrow' constraint.
 --
--- @since unreleased
+-- @since 2.1.0.0
 class MonadThrow m => MonadDejaFu m where
   -- | The type of mutable references.  These references will always
   -- contain a value, and so don't need to handle emptiness (like
@@ -90,7 +90,7 @@ class MonadThrow m => MonadDejaFu m where
 
 -- | A bound thread in @IO@.
 --
--- @since unreleased
+-- @since 2.1.0.0
 data IOBoundThread a = IOBoundThread
   { iobtRunInBoundThread :: IO a -> IO a
     -- ^ Pass an action to the bound thread, run it, and return the
@@ -99,7 +99,7 @@ data IOBoundThread a = IOBoundThread
     -- ^ Terminate the bound thread.
   }
 
--- | @since unreleased
+-- | @since 2.1.0.0
 instance MonadDejaFu IO where
   type Ref IO = IO.IORef
 
@@ -131,7 +131,7 @@ instance MonadDejaFu IO where
 
 -- | This instance does not support bound threads.
 --
--- @since unreleased
+-- @since 2.1.0.0
 instance MonadDejaFu (CatchT (ST.ST t)) where
   type Ref (CatchT (ST.ST t)) = ST.STRef t
 

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -116,6 +116,8 @@ data ThreadAction =
   -- ^ Start a new thread.
   | ForkOS ThreadId
   -- ^ Start a new bound thread.
+  | SupportsBoundThreads Bool
+  -- ^ Check if bound threads are supported.
   | IsCurrentThreadBound Bool
   -- ^ Check if the current thread is bound.
   | MyThreadId
@@ -206,6 +208,7 @@ data ThreadAction =
 instance NFData ThreadAction where
   rnf (Fork t) = rnf t
   rnf (ForkOS t) = rnf t
+  rnf (SupportsBoundThreads b) = rnf b
   rnf (IsCurrentThreadBound b) = rnf b
   rnf MyThreadId = ()
   rnf (GetNumCapabilities i) = rnf i
@@ -252,6 +255,8 @@ data Lookahead =
   -- ^ Will start a new thread.
   | WillForkOS
   -- ^ Will start a new bound thread.
+  | WillSupportsBoundThreads
+  -- ^ Will check if bound threads are supported.
   | WillIsCurrentThreadBound
   -- ^ Will check if the current thread is bound.
   | WillMyThreadId
@@ -331,6 +336,7 @@ data Lookahead =
 instance NFData Lookahead where
   rnf WillFork = ()
   rnf WillForkOS = ()
+  rnf WillSupportsBoundThreads = ()
   rnf WillIsCurrentThreadBound = ()
   rnf WillMyThreadId = ()
   rnf WillGetNumCapabilities = ()

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             2.0.0.1
+version:             2.1.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -20,7 +20,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Michael Walker
 maintainer:          mike@barrucadu.co.uk
-copyright:           (c) 2015--2018 Michael Walker
+copyright:           (c) 2015--2019 Michael Walker
 category:            Concurrency
 build-type:          Simple
 extra-source-files:  README.markdown CHANGELOG.rst
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-2.0.0.1
+  tag:      dejafu-2.1.0.0
 
 library
   exposed-modules:     Test.DejaFu
@@ -59,7 +59,7 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base              >=4.9 && <5
-                     , concurrency       >=1.6 && <1.7
+                     , concurrency       >=1.7 && <1.8
                      , containers        >=0.5 && <0.7
                      , contravariant     >=1.2 && <1.6
                      , deepseq           >=1.1 && <2

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,10 +27,10 @@ There are a few different packages under the Déjà Fu umbrella:
 .. csv-table::
    :header: "Package", "Version", "Summary"
 
-   ":hackage:`concurrency`",  "1.6.2.0",  "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "2.0.0.1", "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "2.0.0.0",  "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "2.0.0.0",  "Déjà Fu support for the tasty test framework"
+   ":hackage:`concurrency`",  "1.7.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
+   ":hackage:`dejafu`",       "2.1.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "2.0.0.1",  "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "2.0.0.1",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+2.0.0.1 (2019-03-24)
+--------------------
+
+* Git: :tag:`hunit-dejafu-2.0.0.1`
+* Hackage: :hackage:`hunit-dejafu-2.0.0.1`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <2.2
+
+
 2.0.0.0 (2019-02-12)
 --------------------
 

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             2.0.0.0
+version:             2.0.0.1
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-2.0.0.0
+  tag:      hunit-dejafu-2.0.0.1
 
 library
   exposed-modules:     Test.HUnit.DejaFu
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.9 && <5
                      , exceptions >=0.7 && <0.11
-                     , dejafu     >=2.0 && <2.1
+                     , dejafu     >=2.0 && <2.2
                      , HUnit      >=1.3.1 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+2.0.0.1 (2019-03-24)
+--------------------
+
+* Git: :tag:`tasty-dejafu-2.0.0.1`
+* Hackage: :hackage:`tasty-dejafu-2.0.0.1`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <2.2
+
+
 2.0.0.0 (2019-02-12)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             2.0.0.0
+version:             2.0.0.1
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,14 +30,14 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-2.0.0.0
+  tag:      tasty-dejafu-2.0.0.1
 
 library
   exposed-modules:     Test.Tasty.DejaFu
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.9  && <5
-                     , dejafu >=2.0  && <2.1
+                     , dejafu >=2.0  && <2.2
                      , random >=1.0  && <1.2
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.3


### PR DESCRIPTION
## Summary

Once upon a time, you could run dejafu things in `ST` as well as `IO`.  This caused a lot of duplication in the API, and I got rid of it when adding support for bound threads.

This PR brings it back by making a couple of smallish changes to `concurrency` and `dejafu`:

- Make it possible for test executions to opt out of bound threads:
    - Deprecate the top-level `rtsSupportsBoundThreads :: Bool`
    - Add a new `supportsBoundThreads :: m Bool` to `MonadConc`

- Drop the `MonadConc` dependency from the test functions:
    - Add a new `MonadDejaFu` class, capturing all the needed `MonadConc` functionality
    - Reimplement everything in terms of `MonadDejaFu`

So now we can run things in `IO` with bound threads as before:

```
> import qualified Control.Concurrent.Classy as C

> resultsSet defaultWay defaultMemType C.supportsBoundThreads
fromList [Right True]

> resultsSet defaultWay defaultMemType $ C.forkOS (pure ())
fromList [Right 1]
```

Or with `CatchT (ST t)`:

```
> import Control.Monad.ST
> import Control.Monad.Catch.Pure
> import qualified Control.Concurrent.Classy as C

> runST $ runCatchT $ resultsSet defaultWay defaultMemType C.supportsBoundThreads
Right (fromList [Right False])

> runST $ runCatchT $ resultsSet defaultWay defaultMemType $ C.forkOS (pure ())
Right (fromList [Left (UncaughtException (MonadFailException "dejafu is running with bound threads disabled - do not use forkOS"))])
```

The `CatchT` is needed because dejafu uses `MonadThrow` to communicate internal errors encountered while running a test execution.

Note: Most of `Test.DejaFu` still needs `MonadIO`, this is because it prints stuff.

**To do:**

- [x] Documentation