### PR TITLE
Fix CI issues

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -41,3 +41,9 @@
 - ignore: {name: Reduce duplication, within: Integration.MultiThreaded}
 - ignore: {name: Reduce duplication, within: Integration.SCT}
 - ignore: {name: Reduce duplication, within: Integration.SingleThreaded}
+
+# These are tests of the laws
+- ignore: {name: "Use <$>", within: Examples.ClassLaws}
+- ignore: {name: "Alternative law, right identity", within: Examples.ClassLaws}
+- ignore: {name: "Alternative law, left identity", within: Examples.ClassLaws}
+- ignore: {name: "Monoid law, right identity", within: Unit.Properties}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,16 +39,16 @@ jobs:
     env: MODE=lint
   - stage: test
     if: type != pull_request
-    env: MODE=test RESOLVER=lts-9.0  # GHC 8.0
+    env: MODE=test RESOLVER=lts-9.0  STACKVER=1.6.1 # GHC 8.0
   - stage: test
     if: type != pull_request
-    env: MODE=test RESOLVER=lts-10.0 # GHC 8.2
+    env: MODE=test RESOLVER=lts-10.0 STACKVER=1.6.1 # GHC 8.2
   - stage: test
     if: type != pull_request
-    env: MODE=test RESOLVER=lts-12.0 # GHC 8.4
+    env: MODE=test RESOLVER=lts-12.0 STACKVER=1.7.1 # GHC 8.4
   - stage: test
     if: type != pull_request
-    env: MODE=test RESOLVER=lts-13.3 # GHC 8.6 - .3 because hedgehog and stylish-haskell aren't in .0
+    env: MODE=test RESOLVER=lts-13.3 STACKVER=1.9.3 # GHC 8.6 - .3 because hedgehog and stylish-haskell aren't in .0
   - stage: test
     if: type != pull_request
     env: MODE=test RESOLVER=nightly

--- a/.travis/lint
+++ b/.travis/lint
@@ -6,7 +6,7 @@ $stack install stylish-haskell
 
 $stack build
 
-curl -sL https://raw.github.com/ndmitchell/weeder/master/misc/travis.sh | sh -s .
+#curl -sL https://raw.github.com/ndmitchell/weeder/master/misc/travis.sh | sh -s .
 curl -sL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh  | sh -s .
 
 $stack exec ./style.sh

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -8,8 +8,13 @@ stack="stack --no-terminal"
 
 mkdir -p ~/.local/bin
 
-curl -L https://www.stackage.org/stack/linux-x86_64 | \
-  tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+if [[ -z "$STACKVER" ]]; then
+  curl -L https://www.stackage.org/stack/linux-x86_64 | \
+    tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+else
+  curl -L https://github.com/commercialhaskell/stack/releases/download/v$STACKVER/stack-$STACKVER-linux-x86_64.tar.gz | \
+    tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+fi
 
 if [[ -e ".travis/$RESOLVER.yaml" ]]; then
   mv ".travis/$RESOLVER.yaml" stack.yaml

--- a/.travis/test
+++ b/.travis/test
@@ -2,7 +2,7 @@
 
 source .travis/setup.sh
 
-$stack build --ghc-options=-Werror
+$stack build --ghc-options="-Werror -Wno-unused-imports"
 
 cd dejafu-tests
 $stack exec -- dejafu-tests +RTS -s


### PR DESCRIPTION
## Summary

There's been some CI bit-rot:

- Latest stack doesn't support all the older LTSes I use, so the version needs pinning
- Unused import warnings have cropped up, but I remember making a conscious decision in the past not to use CPP to suppress those (too much cognitive overhead thinking "why is this CPP here?")
- Weeder seems to have broken, or changed how it's supposed to be invoked, but I can't see how to fix it
- Hlint has more lints

As this only affects CI scripts, no new releases are needed.