### PR TITLE
Support GHC 8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,9 @@ jobs:
     env: MODE=test RESOLVER=lts-13.3 STACKVER=1.9.3 # GHC 8.6 - .3 because hedgehog and stylish-haskell aren't in .0
   - stage: test
     if: type != pull_request
+    env: MODE=test RESOLVER=nightly-2019-10-02 STACKVER=2.1.3 # GHC 8.8 - no lts yet
+  - stage: test
+    if: type != pull_request
     env: MODE=test RESOLVER=nightly
 
   - stage: predeploy

--- a/README.markdown
+++ b/README.markdown
@@ -45,8 +45,8 @@ There are a few different packages under the Déjà Fu umbrella:
 
 |   | Version | Summary |
 | - | ------- | ------- |
-| [concurrency][h:conc]    | 1.7.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 2.1.0.0  | Systematic testing for Haskell concurrency. |
+| [concurrency][h:conc]    | 1.8.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
+| [dejafu][h:dejafu]       | 2.1.0.1  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.1  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 2.0.0.1  | Deja Fu support for the Tasty test framework. |
 

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.8.0.0 (2019-10-04)
+--------------------
+
+* Git: :tag:`concurrency-1.8.0.0`
+* Hackage: :hackage:`concurrency-1.8.0.0`
 
 Added
 ~~~~~

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -16,6 +16,18 @@ Added
 * ``MonadFail`` instances for ``Control.Monad.Conc.Class.IsConc`` and
   ``Control.Monad.STM.IsSTM``.
 
+Changed
+~~~~~~~
+
+* Added ``MonadFail`` constraints to
+  ``Control.Concurrent.Classy.QSem.newQSem`` and
+  ``Control.Concurrent.Classy.QSemN.newQSemN``.
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* Fixed a compilation error with GHC 8.8
+
 
 1.7.0.0 (2019-03-24)
 --------------------

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,6 +7,16 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Added
+~~~~~
+
+* ``MonadFail`` instances for ``Control.Monad.Conc.Class.IsConc`` and
+  ``Control.Monad.STM.IsSTM``.
+
+
 1.7.0.0 (2019-03-24)
 --------------------
 

--- a/concurrency/Control/Concurrent/Classy/QSem.hs
+++ b/concurrency/Control/Concurrent/Classy/QSem.hs
@@ -17,6 +17,7 @@ module Control.Concurrent.Classy.QSem
 
 import           Control.Concurrent.Classy.QSemN
 import           Control.Monad.Conc.Class        (MonadConc)
+import           Control.Monad.Fail              (MonadFail)
 
 -- | @QSem@ is a quantity semaphore in which the resource is acquired
 -- and released in units of one. It provides guaranteed FIFO ordering
@@ -35,7 +36,7 @@ newtype QSem m = QSem (QSemN m)
 -- quantity must be at least 0.
 --
 -- @since 1.0.0.0
-newQSem :: MonadConc m => Int -> m (QSem m)
+newQSem :: (MonadConc m, MonadFail m) => Int -> m (QSem m)
 newQSem initial
   | initial < 0 = fail "newQSem: Initial quantity mus tbe non-negative."
   | otherwise   = QSem <$> newQSemN initial

--- a/concurrency/Control/Concurrent/Classy/QSemN.hs
+++ b/concurrency/Control/Concurrent/Classy/QSemN.hs
@@ -20,6 +20,7 @@ import           Control.Concurrent.Classy.MVar
 import           Control.Monad.Catch            (mask_, onException,
                                                  uninterruptibleMask_)
 import           Control.Monad.Conc.Class       (MonadConc)
+import           Control.Monad.Fail             (MonadFail)
 import           Data.Maybe
 
 -- | 'QSemN' is a quantity semaphore in which the resource is aqcuired
@@ -39,7 +40,7 @@ newtype QSemN m = QSemN (MVar m (Int, [(Int, MVar m ())], [(Int, MVar m ())]))
 --  The initial quantity must be at least 0.
 --
 -- @since 1.0.0.0
-newQSemN :: MonadConc m => Int -> m (QSemN m)
+newQSemN :: (MonadConc m, MonadFail m) => Int -> m (QSemN m)
 newQSemN initial
   | initial < 0 = fail "newQSemN: Initial quantity must be non-negative"
   | otherwise   = QSemN <$> newMVar (initial, [], [])

--- a/concurrency/Control/Monad/Conc/Class.hs
+++ b/concurrency/Control/Monad/Conc/Class.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -12,7 +13,7 @@
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
--- Portability : CPP, FlexibleContexts, PolyKinds, RankNTypes, ScopedTypeVariables, TypeFamilies
+-- Portability : CPP, FlexibleContexts, PolyKinds, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeFamilies
 --
 -- This module captures in a typeclass the interface of concurrency
 -- monads.
@@ -94,6 +95,7 @@ import           Control.Exception            (AsyncException(ThreadKilled),
 import           Control.Monad.Catch          (MonadCatch, MonadMask,
                                                MonadThrow)
 import qualified Control.Monad.Catch          as Ca
+import           Control.Monad.Fail           (MonadFail(..))
 import           Control.Monad.STM.Class      (IsSTM, MonadSTM, TVar, fromIsSTM,
                                                readTVar)
 import           Control.Monad.Trans.Control  (MonadTransControl, StT, liftWith)
@@ -790,6 +792,9 @@ labelMe n  = do
 -- @since 1.2.2.0
 newtype IsConc m a = IsConc { unIsConc :: m a }
   deriving (Functor, Applicative, Monad, MonadThrow, MonadCatch, MonadMask)
+
+-- | @since unreleased
+deriving instance MonadFail m => MonadFail (IsConc m)
 
 -- | Wrap an @m a@ value inside an @IsConc@ if @m@ has a @MonadConc@
 -- instance.

--- a/concurrency/Control/Monad/Conc/Class.hs
+++ b/concurrency/Control/Monad/Conc/Class.hs
@@ -793,7 +793,7 @@ labelMe n  = do
 newtype IsConc m a = IsConc { unIsConc :: m a }
   deriving (Functor, Applicative, Monad, MonadThrow, MonadCatch, MonadMask)
 
--- | @since unreleased
+-- | @since 1.8.0.0
 deriving instance MonadFail m => MonadFail (IsConc m)
 
 -- | Wrap an @m a@ value inside an @IsConc@ if @m@ has a @MonadConc@

--- a/concurrency/Control/Monad/STM/Class.hs
+++ b/concurrency/Control/Monad/STM/Class.hs
@@ -187,7 +187,7 @@ instance MonadSTM STM.STM where
 newtype IsSTM m a = IsSTM { unIsSTM :: m a }
   deriving (Functor, Applicative, Alternative, Monad, MonadPlus, Ca.MonadThrow, Ca.MonadCatch)
 
--- | @since unreleased
+-- | @since 1.8.0.0
 deriving instance MonadFail m => MonadFail (IsSTM m)
 
 -- | Wrap an @m a@ value inside an @IsSTM@ if @m@ has a @MonadSTM@

--- a/concurrency/Control/Monad/STM/Class.hs
+++ b/concurrency/Control/Monad/STM/Class.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -9,7 +10,7 @@
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
--- Portability : CPP, RankNTypes, TemplateHaskell, TypeFamilies
+-- Portability : CPP, RankNTypes, StandaloneDeriving, TemplateHaskell, TypeFamilies
 --
 -- This module provides an abstraction over 'STM', which can be used
 -- with 'MonadConc'.
@@ -62,6 +63,7 @@ module Control.Monad.STM.Class
 import           Control.Applicative          (Alternative(..))
 import           Control.Exception            (Exception)
 import           Control.Monad                (MonadPlus(..), unless)
+import           Control.Monad.Fail           (MonadFail(..))
 import           Control.Monad.Reader         (ReaderT)
 import           Control.Monad.Trans          (lift)
 import           Control.Monad.Trans.Identity (IdentityT)
@@ -184,6 +186,9 @@ instance MonadSTM STM.STM where
 -- @since 1.2.2.0
 newtype IsSTM m a = IsSTM { unIsSTM :: m a }
   deriving (Functor, Applicative, Alternative, Monad, MonadPlus, Ca.MonadThrow, Ca.MonadCatch)
+
+-- | @since unreleased
+deriving instance MonadFail m => MonadFail (IsSTM m)
 
 -- | Wrap an @m a@ value inside an @IsSTM@ if @m@ has a @MonadSTM@
 -- instance.

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                concurrency
-version:             1.7.0.0
+version:             1.8.0.0
 synopsis:            Typeclasses, functions, and data types for concurrency and STM.
 
 description:
@@ -32,7 +32,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      concurrency-1.7.0.0
+  tag:      concurrency-1.8.0.0
 
 library
   exposed-modules:     Control.Monad.Conc.Class

--- a/dejafu-tests/lib/Integration/SingleThreaded.hs
+++ b/dejafu-tests/lib/Integration/SingleThreaded.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 module Integration.SingleThreaded where
 
 import           Control.Exception         (ArithException(..),
@@ -12,6 +14,7 @@ import           Test.DejaFu               (Condition(..), gives, gives',
 import           Control.Concurrent.Classy
 import           Control.Monad             (replicateM_, when)
 import           Control.Monad.Catch       (throwM)
+import           Control.Monad.Fail        (MonadFail)
 import           Control.Monad.IO.Class    (liftIO)
 import qualified Data.IORef                as IORef
 import           Data.Maybe                (isNothing)
@@ -167,7 +170,7 @@ stmTests = toTestList
       (6==) <$> readTVarConc ctv
 
   , djfu "MonadSTM is a MonadFail" (alwaysFailsWith isUncaughtException)
-      (atomically $ fail "hello world" :: MonadConc m => m ())  -- avoid an ambiguous type
+      (atomically $ fail "hello world" :: (MonadConc m, MonadFail (STM m)) => m ())  -- avoid an ambiguous type
 
   , djfu "'retry' is not caught by 'catch'" (gives' [True]) $
       atomically
@@ -226,7 +229,7 @@ exceptionTests = toTestList
       catchArithException (throwTo tid Overflow >> pure False) (\_ -> pure True)
 
   , djfu "MonadConc is a MonadFail" (alwaysFailsWith isUncaughtException)
-      (fail "hello world" :: MonadConc m => m ())  -- avoid an ambiguous type
+      (fail "hello world" :: (MonadConc m, MonadFail m) => m ())  -- avoid an ambiguous type
   ]
 
 --------------------------------------------------------------------------------

--- a/dejafu-tests/lib/QSemN.hs
+++ b/dejafu-tests/lib/QSemN.hs
@@ -5,11 +5,12 @@ import           Control.Concurrent.Classy.MVar
 import           Control.Monad.Catch            (mask_, onException,
                                                  uninterruptibleMask_)
 import           Control.Monad.Conc.Class       (MonadConc)
+import           Control.Monad.Fail             (MonadFail)
 import           Data.Maybe
 
 newtype QSemN m = QSemN (MVar m (Int, [(Int, MVar m ())], [(Int, MVar m ())]))
 
-newQSemN :: MonadConc m => Int -> m (QSemN m)
+newQSemN :: (MonadConc m, MonadFail m) => Int -> m (QSemN m)
 newQSemN initial
   | initial < 0 = fail "newQSemN: Initial quantity must be non-negative"
   | otherwise   = QSemN <$> newMVar (initial, [], [])

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 module Unit.Properties where
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,15 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* Fixed a compilation error with GHC 8.8
+
+
 2.1.0.0 (2019-03-24)
 --------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,13 +7,17 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+2.1.0.1 (2019-10-04)
+--------------------
+
+* Git: :tag:`dejafu-2.1.0.1`
+* Hackage: :hackage:`dejafu-2.1.0.1`
 
 Miscellaneous
 ~~~~~~~~~~~~~
 
 * Fixed a compilation error with GHC 8.8
+* The upper version bound on :hackage:`concurrency` is <1.9.
 
 
 2.1.0.0 (2019-03-24)

--- a/dejafu/Test/DejaFu/Conc/Internal/Common.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Common.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
@@ -8,7 +9,7 @@
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
--- Portability : ExistentialQuantification, GADTs, RankNTypes
+-- Portability : CPP, ExistentialQuantification, GADTs, RankNTypes
 --
 -- Common types and utility functions for deterministic execution of
 -- 'MonadConc' implementations. This module is NOT considered to form
@@ -95,8 +96,12 @@ instance (pty ~ Basic) => Applicative (Program pty n) where
 
 instance (pty ~ Basic) => Monad (Program pty n) where
   return  = pure
-  fail    = Fail.fail
   m >>= k = ModelConc $ \c -> runModelConc m (\x -> runModelConc (k x) c)
+
+#if MIN_VERSION_base(4,13,0)
+#else
+  fail = Fail.fail
+#endif
 
 instance (pty ~ Basic) => Fail.MonadFail (Program pty n) where
   fail e = ModelConc $ \_ -> AThrow (MonadFailException e)
@@ -243,8 +248,12 @@ instance Applicative (Invariant n) where
 
 instance Monad (Invariant n) where
   return  = pure
-  fail    = Fail.fail
   m >>= k = Invariant $ \c -> runInvariant m (\x -> runInvariant (k x) c)
+
+#if MIN_VERSION_base(4,13,0)
+#else
+  fail = Fail.fail
+#endif
 
 instance Fail.MonadFail (Invariant n) where
   fail e = Invariant $ \_ -> IThrow (MonadFailException e)

--- a/dejafu/Test/DejaFu/Conc/Internal/STM.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/STM.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -11,7 +12,7 @@
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
--- Portability : ExistentialQuantification, NoMonoLocalBinds, RecordWildCards, TypeFamilies
+-- Portability : CPP, ExistentialQuantification, NoMonoLocalBinds, RecordWildCards, TypeFamilies
 --
 -- 'MonadSTM' testing implementation, internal types and definitions.
 -- This module is NOT considered to form part of the public interface
@@ -51,7 +52,10 @@ instance Monad (ModelSTM n) where
     return  = pure
     m >>= k = ModelSTM $ \c -> runModelSTM m (\x -> runModelSTM (k x) c)
 
+#if MIN_VERSION_base(4,13,0)
+#else
     fail = Fail.fail
+#endif
 
 instance Fail.MonadFail (ModelSTM n) where
     fail e = ModelSTM $ \_ -> SThrow (MonadFailException e)

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             2.1.0.0
+version:             2.1.0.1
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-2.1.0.0
+  tag:      dejafu-2.1.0.1
 
 library
   exposed-modules:     Test.DejaFu
@@ -59,7 +59,7 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base              >=4.9 && <5
-                     , concurrency       >=1.7 && <1.8
+                     , concurrency       >=1.7 && <1.9
                      , containers        >=0.5 && <0.7
                      , contravariant     >=1.2 && <1.6
                      , deepseq           >=1.1 && <2

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,8 +27,8 @@ There are a few different packages under the Déjà Fu umbrella:
 .. csv-table::
    :header: "Package", "Version", "Summary"
 
-   ":hackage:`concurrency`",  "1.7.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "2.1.0.0", "Systematic testing for Haskell concurrency"
+   ":hackage:`concurrency`",  "1.8.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
+   ":hackage:`dejafu`",       "2.1.0.1", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.1",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "2.0.0.1",  "Déjà Fu support for the tasty test framework"
 

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -8,6 +8,7 @@ The currently supported versions are:
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
+   "8.8",  "",         "4.13.0.0"
    "8.6",  "LTS 13.0", "4.12.0.0"
    "8.4",  "LTS 12.0", "4.11.0.0"
    "8.2",  "LTS 10.0", "4.10.1.0"


### PR DESCRIPTION
## Summary

Get everything working with the latest stackage nightly (which has GHC 8.8).

This has a breaking change to `concurrency`: the addition of a `MonadFail m` constraint to `newQSem` and `newQSemN`.

I decided not to add a `MonadFail` superclass constraint to `MonadConc`, because the only method of `MonadConc` which can fail is `forkOSWithUnmask`, and it's concievable that some instance could be written which never fails (eg, there's some compile-time constraint that it's built against a threaded runtime, or GHC drops the non-threaded runtime, or it just lies and emulates OS threads somehow).