### PR TITLE
Add newTVarConc to MonadConc

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,7 @@ There are a few different packages under the Déjà Fu umbrella:
 
 |   | Version | Summary |
 | - | ------- | ------- |
-| [concurrency][h:conc]    | 1.8.0.0  | Typeclasses, functions, and data types for concurrency and STM. |
+| [concurrency][h:conc]    | 1.8.1.0  | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 2.1.0.1  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.1  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 2.0.0.1  | Deja Fu support for the Tasty test framework. |

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,6 +7,16 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+==========
+
+Added
+~~~~~
+
+* (:issue:`303`) ``Control.Monad.Conc.Class.newTVarConc``, with a
+  default implementation of ``atomically . newTVar``.
+
+
 1.8.0.0 (2019-10-04)
 --------------------
 

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-==========
+1.8.1.0 (2019-11-16)
+====================
+
+* Git: :tag:`concurrency-1.8.1.0`
+* Hackage: :hackage:`concurrency-1.8.1.0`
 
 Added
 ~~~~~

--- a/concurrency/Control/Monad/Conc/Class.hs
+++ b/concurrency/Control/Monad/Conc/Class.hs
@@ -476,7 +476,7 @@ class ( Monad m
   --
   -- > newTVarConc = atomically . newTVar
   --
-  -- @since unreleased
+  -- @since 1.8.1.0
   newTVarConc :: a -> m (TVar (STM m) a)
   newTVarConc = atomically . newTVar
 

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                concurrency
-version:             1.8.0.0
+version:             1.8.1.0
 synopsis:            Typeclasses, functions, and data types for concurrency and STM.
 
 description:
@@ -32,7 +32,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      concurrency-1.8.0.0
+  tag:      concurrency-1.8.1.0
 
 library
   exposed-modules:     Control.Monad.Conc.Class

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,7 +27,7 @@ There are a few different packages under the Déjà Fu umbrella:
 .. csv-table::
    :header: "Package", "Version", "Summary"
 
-   ":hackage:`concurrency`",  "1.8.0.0",  "Typeclasses, functions, and data types for concurrency and STM"
+   ":hackage:`concurrency`",  "1.8.1.0",  "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "2.1.0.1", "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.1",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "2.0.0.1",  "Déjà Fu support for the tasty test framework"


### PR DESCRIPTION
## Summary

Adds `newTVarConc` to `MonadConc` with a default definition of `atomically . newTVar`.  As this has a default definition, it's not a breaking change.

**Related issues:** #303
