### PR TITLE
Get dejafu-tests building with hedgehog-1.0.2

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -37,6 +37,7 @@
 # I don't think these help.
 - ignore: {name: Avoid lambda, within: Integration.Refinement}
 - ignore: {name: Reduce duplication, within: Unit.Properties}
+- ignore: {name: Use nonTermination, within: Unit.Properties}
 - ignore: {name: Reduce duplication, within: Integration.Litmus}
 - ignore: {name: Reduce duplication, within: Integration.MultiThreaded}
 - ignore: {name: Reduce duplication, within: Integration.SCT}
@@ -44,6 +45,7 @@
 
 # These are tests of the laws
 - ignore: {name: "Use <$>", within: Examples.ClassLaws}
+- ignore: {name: "Use fmap", within: Examples.ClassLaws}
 - ignore: {name: "Alternative law, right identity", within: Examples.ClassLaws}
 - ignore: {name: "Alternative law, left identity", within: Examples.ClassLaws}
 - ignore: {name: "Monoid law, right identity", within: Unit.Properties}

--- a/concurrency/Control/Concurrent/Classy/STM/TMVar.hs
+++ b/concurrency/Control/Concurrent/Classy/STM/TMVar.hs
@@ -29,7 +29,7 @@ module Control.Concurrent.Classy.STM.TMVar
   , swapTMVar
   ) where
 
-import           Control.Monad           (liftM, unless, when)
+import           Control.Monad           (unless, when)
 import           Control.Monad.STM.Class
 import           Data.Maybe              (isJust, isNothing)
 
@@ -131,7 +131,7 @@ tryReadTMVar (TMVar ctvar) = readTVar ctvar
 --
 -- @since 1.0.0.0
 isEmptyTMVar :: MonadSTM stm => TMVar stm a -> stm Bool
-isEmptyTMVar ctmvar = isNothing `liftM` tryReadTMVar ctmvar
+isEmptyTMVar ctmvar = isNothing <$> tryReadTMVar ctmvar
 
 -- | Swap the contents of a 'TMVar' returning the old contents, or
 -- 'retry' if it is empty.

--- a/dejafu-tests/lib/Examples/Philosophers.hs
+++ b/dejafu-tests/lib/Examples/Philosophers.hs
@@ -33,7 +33,7 @@ settings = set llengthBound (Just 30) defaultSettings
 philosophers :: MonadConc m => Int -> m ()
 philosophers n = do
   forks <- replicateM n newEmptyMVar
-  let phils = map (\(i,p) -> p i forks) $ zip [0..] $ replicate n philosopher
+  let phils = zipWith (\i p -> p i forks) [0..] (replicate n philosopher)
   cvars <- mapM spawn phils
   mapM_ takeMVar cvars
 

--- a/dejafu-tests/lib/Integration/Names.hs
+++ b/dejafu-tests/lib/Integration/Names.hs
@@ -93,7 +93,7 @@ testTVarNames =
     checkTVars =
       let validTVar =
             maybe False (`elem` [tvarName1, tvarName2]) . tvarName
-      in all (all validTVar) . map tvarsOf
+      in all (all validTVar . tvarsOf)
 
 testThreadNames :: Assertion
 testThreadNames =
@@ -113,4 +113,4 @@ testThreadNames =
       let validTid =
             maybe False (`elem` [threadName1, threadName2, threadName3]) .
             threadName
-      in all (all validTid) . map tidsOf
+      in all (all validTid . tidsOf)


### PR DESCRIPTION
## Summary

Get dejafu-tests building against hedgehog-1.0.2, which is in the latest stackage snapshots.

This is only a temporary fix, ideally we'd use tasty-hedgehog directly, though getting that in older stackage snapshots may be a pain and require pulling in a lot of non-snapshot dependencies.
