### PR TITLE
LTS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
     env: MODE=test RESOLVER=lts-13.3 STACKVER=1.9.3 # GHC 8.6 - .3 because hedgehog and stylish-haskell aren't in .0
   - stage: test
     if: type != pull_request
-    env: MODE=test RESOLVER=nightly-2019-10-02 STACKVER=2.1.3 # GHC 8.8 - no lts yet
+    env: MODE=test RESOLVER=lts-15.0 STACKVER=2.1.3 # GHC 8.8
   - stage: test
     if: type != pull_request
     env: MODE=test RESOLVER=nightly

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -1,9 +1,9 @@
 Supported GHC Versions
 ======================
 
-Déjà Fu supports the latest four GHC releases, after GHC 8.0.  For
-testing purposes, we use Stackage LTSes as a proxy for GHC versions.
-The currently supported versions are:
+Déjà Fu supports the latest four GHC releases, at least.  For testing
+purposes, we use Stackage LTSes as a proxy for GHC versions.  The
+currently supported versions are:
 
 .. csv-table::
    :header: "GHC", "Stackage", "base"

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -8,7 +8,7 @@ The currently supported versions are:
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
-   "8.8",  "",         "4.13.0.0"
+   "8.8",  "LTS 15.0", "4.13.0.0"
    "8.6",  "LTS 13.0", "4.12.0.0"
    "8.4",  "LTS 12.0", "4.11.0.0"
    "8.2",  "LTS 10.0", "4.10.1.0"


### PR DESCRIPTION
## Summary

There's an LTS for GHC 8.8 now (and has been for a while), so use it.