### PR TITLE
Add unsafeUnmask to MonadConc

### DIFF
--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -6,6 +6,14 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+unreleased
+----------
+
+Added
+~~~~~
+
+* (:issue:`316`) ``Control.Monad.Conc.Class.unsafeUnmask``.
+
 1.10.0.0 (2020-05-10)
 ---------------------
 


### PR DESCRIPTION
## Summary

Adds `unsafeUnmask` to `MonadConc`.

**Related issues:**

#316 

## Checklist

**If this is fixing a bug or adding a feature:**

- [ ] Add new tests to dejafu-tests