### PR TITLE
Add unsafeUnmask to MonadConc (attempt 2)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,8 +47,8 @@ There are a few different packages under the Déjà Fu umbrella:
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.11.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 2.3.0.0  | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 2.0.0.2  | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 2.0.0.3  | Deja Fu support for the Tasty test framework. |
+| [hunit-dejafu][h:hunit]  | 2.0.0.3  | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 2.0.0.4  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/README.markdown
+++ b/README.markdown
@@ -46,7 +46,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.11.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 2.2.0.0  | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 2.3.0.0  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.2  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 2.0.0.3  | Deja Fu support for the Tasty test framework. |
 

--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,7 @@ There are a few different packages under the Déjà Fu umbrella:
 
 |   | Version | Summary |
 | - | ------- | ------- |
-| [concurrency][h:conc]    | 1.10.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
+| [concurrency][h:conc]    | 1.11.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 2.2.0.0  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.2  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 2.0.0.3  | Deja Fu support for the Tasty test framework. |

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -6,14 +6,20 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
-unreleased
-----------
+1.11.0.0 (2020-05-14)
+--------------------
+
+* Git: :tag:`concurrency-1.11.0.0`
+* Hackage: :hackage:`concurrency-1.11.0.0`
+
+**Contributors:** :u:`mitchellwrosen` (:pull:`319`).
 
 Added
 ~~~~~
 
 * (:issue:`316`) ``Control.Monad.Conc.Class.unsafeUnmask``.
 * ``Control.Monad.Conc.Class.interruptible``.
+
 
 1.10.0.0 (2020-05-10)
 ---------------------

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 ~~~~~
 
 * (:issue:`316`) ``Control.Monad.Conc.Class.unsafeUnmask``.
+* ``Control.Monad.Conc.Class.interruptible``.
 
 1.10.0.0 (2020-05-10)
 ---------------------

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -6,6 +6,14 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+unreleased
+----------
+
+Added
+~~~~~
+
+* (:issue:`316`) ``Control.Monad.Conc.Class.unsafeUnmask``.
+
 1.10.0.0 (2020-05-10)
 ---------------------
 

--- a/concurrency/Control/Monad/Conc/Class.hs
+++ b/concurrency/Control/Monad/Conc/Class.hs
@@ -9,7 +9,7 @@
 
 -- |
 -- Module      : Control.Monad.Conc.Class
--- Copyright   : (c) 2016--2019 Michael Walker
+-- Copyright   : (c) 2016--2020 Michael Walker
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
@@ -156,7 +156,7 @@ import qualified Control.Monad.Writer.Strict  as WS
 -- Do not be put off by the use of @UndecidableInstances@, it is safe
 -- here.
 --
--- @since unreleased
+-- @since 1.11.0.0
 class ( Monad m
       , MonadCatch m, MonadThrow m, MonadMask m
       , MonadSTM (STM m)
@@ -508,6 +508,8 @@ class ( Monad m
   getMaskingState :: m MaskingState
 
   -- | Set the 'MaskingState' for the current thread to 'MaskedUninterruptible'.
+  --
+  -- @since 1.11.0.0
   unsafeUnmask :: m a -> m a
 
 -------------------------------------------------------------------------------
@@ -707,7 +709,7 @@ uninterruptibleMask = Ca.uninterruptibleMask
 -- When called outside 'mask', or inside 'uninterruptibleMask', this
 -- function has no effect.
 --
--- @since unreleased
+-- @since 1.11.0.0
 interruptible :: MonadConc m => m a -> m a
 interruptible act = do
   st <- getMaskingState

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                concurrency
-version:             1.10.0.0
+version:             1.11.0.0
 synopsis:            Typeclasses, functions, and data types for concurrency and STM.
 
 description:
@@ -19,7 +19,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Michael Walker
 maintainer:          mike@barrucadu.co.uk
-copyright:           (c) 2016--2019 Michael Walker
+copyright:           (c) 2016--2020 Michael Walker
 category:            Concurrency
 build-type:          Simple
 extra-source-files:  README.markdown CHANGELOG.rst
@@ -32,7 +32,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      concurrency-1.10.0.0
+  tag:      concurrency-1.11.0.0
 
 library
   exposed-modules:     Control.Monad.Conc.Class

--- a/dejafu-tests/lib/Integration/MultiThreaded.hs
+++ b/dejafu-tests/lib/Integration/MultiThreaded.hs
@@ -244,6 +244,14 @@ exceptionTests = toTestList
       killThread tid
       readMVar y
 
+  , djfuT "Exceptions can kill masked threads which have unsafely unmasked" (gives [Left Deadlock, Right ()]) $ do
+      x <- newEmptyMVar
+      y <- newEmptyMVar
+      tid <- fork $ mask_ $ putMVar x () >> unsafeUnmask (putMVar y ())
+      readMVar x
+      killThread tid
+      readMVar y
+
   , djfuT "Throwing to main kills the computation, if unhandled" (alwaysFailsWith isUncaughtException) $ do
       tid <- myThreadId
       j <- spawn $ throwTo tid Overflow

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,6 +6,15 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The version bound on :hackage:`concurrency` is >=1.11 <1.12.
+
+
 2.2.0.0 (2020-05-10)
 --------------------
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,8 +6,11 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
-unreleased
-----------
+2.3.0.0 (2020-05-14)
+--------------------
+
+* Git: :tag:`dejafu-2.3.0.0`
+* Hackage: :hackage:`dejafu-2.3.0.0`
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/dejafu/Test/DejaFu/Conc/Internal/Program.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Program.hs
@@ -141,6 +141,8 @@ instance (pty ~ Basic, Monad n) => C.MonadConc (Program pty n) where
 
   getMaskingState = ModelConc (\c -> AGetMasking c)
 
+  unsafeUnmask ma = ModelConc (AMasking Unmasked (const ma))
+
   -- ----------
 
   atomically = ModelConc . AAtom

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             2.2.0.0
+version:             2.3.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -20,7 +20,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Michael Walker
 maintainer:          mike@barrucadu.co.uk
-copyright:           (c) 2015--2019 Michael Walker
+copyright:           (c) 2015--2020 Michael Walker
 category:            Concurrency
 build-type:          Simple
 extra-source-files:  README.markdown CHANGELOG.rst
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-2.2.0.0
+  tag:      dejafu-2.3.0.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -59,7 +59,7 @@ library
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base              >=4.9 && <5
-                     , concurrency       >=1.10 && <1.11
+                     , concurrency       >=1.11 && <1.12
                      , containers        >=0.5 && <0.7
                      , contravariant     >=1.2 && <1.6
                      , deepseq           >=1.1 && <2

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.11.0.0", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "2.2.0.0",  "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "2.3.0.0",  "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.2",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "2.0.0.3",  "Déjà Fu support for the tasty test framework"
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -29,8 +29,8 @@ There are a few different packages under the Déjà Fu umbrella:
 
    ":hackage:`concurrency`",  "1.11.0.0", "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "2.3.0.0",  "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "2.0.0.2",  "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "2.0.0.3",  "Déjà Fu support for the tasty test framework"
+   ":hackage:`hunit-dejafu`", "2.0.0.3",  "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "2.0.0.4",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,7 +27,7 @@ There are a few different packages under the Déjà Fu umbrella:
 .. csv-table::
    :header: "Package", "Version", "Summary"
 
-   ":hackage:`concurrency`",  "1.10.0.0", "Typeclasses, functions, and data types for concurrency and STM"
+   ":hackage:`concurrency`",  "1.11.0.0", "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "2.2.0.0",  "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.2",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "2.0.0.3",  "Déjà Fu support for the tasty test framework"

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,7 +7,19 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-2.0.0.2 (2020-10-05)
+2.0.0.3 (2020-05-10)
+--------------------
+
+* Git: :tag:`hunit-dejafu-2.0.0.3`
+* Hackage: :hackage:`hunit-dejafu-2.0.0.3`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <2.4
+
+
+2.0.0.2 (2020-05-10)
 --------------------
 
 * Git: :tag:`hunit-dejafu-2.0.0.2`

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             2.0.0.2
+version:             2.0.0.3
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -17,7 +17,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Michael Walker
 maintainer:          mike@barrucadu.co.uk
-copyright:           (c) 2015--2017 Michael Walker
+copyright:           (c) 2015--2020 Michael Walker
 category:            Testing
 build-type:          Simple
 extra-source-files:  README.markdown CHANGELOG.rst
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-2.0.0.2
+  tag:      hunit-dejafu-2.0.0.3
 
 library
   exposed-modules:     Test.HUnit.DejaFu
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.9 && <5
                      , exceptions >=0.7 && <0.11
-                     , dejafu     >=2.0 && <2.3
+                     , dejafu     >=2.0 && <2.4
                      , HUnit      >=1.3.1 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+2.0.0.4 (2020-05-14)
+--------------------
+
+* Git: :tag:`tasty-dejafu-2.0.0.4`
+* Hackage: :hackage:`tasty-dejafu-2.0.0.4`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <2.4
+
+
 2.0.0.3 (2020-05-10)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             2.0.0.3
+version:             2.0.0.4
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -17,7 +17,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Michael Walker
 maintainer:          mike@barrucadu.co.uk
-copyright:           (c) 2015--2017 Michael Walker
+copyright:           (c) 2015--2020 Michael Walker
 category:            Testing
 build-type:          Simple
 extra-source-files:  README.markdown CHANGELOG.rst
@@ -30,14 +30,14 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-2.0.0.3
+  tag:      tasty-dejafu-2.0.0.4
 
 library
   exposed-modules:     Test.Tasty.DejaFu
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.9  && <5
-                     , dejafu >=2.0  && <2.3
+                     , dejafu >=2.0  && <2.4
                      , random >=1.0  && <1.2
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.4


### PR DESCRIPTION
## Summary

Adds `unsafeUnmask` to `MonadConc`.

**To do:**

- [x] Add `interruptible` to Control.Monad.Conc.Class
- [x] Add it to dejafu
- [x] Bump dejafu, hunit-dejafu, tasty-dejafu versions

**Related issues:** closes #316

## Checklist

**If this is fixing a bug or adding a feature:**

- [x] Add new tests to dejafu-tests

## Benchmark results (for performance issues)

n/a