### PR TITLE
Fix #324

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -40,6 +40,7 @@
 - ignore: {name: Use nonTermination, within: Unit.Properties}
 - ignore: {name: Reduce duplication, within: Integration.Litmus}
 - ignore: {name: Reduce duplication, within: Integration.MultiThreaded}
+- ignore: {name: Reduce duplication, within: Integration.Regressions}
 - ignore: {name: Reduce duplication, within: Integration.SCT}
 - ignore: {name: Reduce duplication, within: Integration.SingleThreaded}
 

--- a/README.markdown
+++ b/README.markdown
@@ -46,9 +46,9 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.11.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 2.3.0.1  | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 2.0.0.3  | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 2.0.0.5  | Deja Fu support for the Tasty test framework. |
+| [dejafu][h:dejafu]       | 2.4.0.0  | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 2.0.0.4  | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 2.0.0.6  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/dejafu-tests/lib/Integration/Regressions.hs
+++ b/dejafu-tests/lib/Integration/Regressions.hs
@@ -61,7 +61,7 @@ tests = toTestList
       tid <- myThreadId
       uninterruptibleMask_ (throwTo tid ThreadKilled)
 
-  , (:[]) . expectFail $ testDejafuWithSettings defaultSettings "https://github.com/barrucadu/dejafu/issues/324 (a)" (gives' [Left ThreadKilled, Left UserInterrupt]) $ do
+  , djfu "https://github.com/barrucadu/dejafu/issues/324 (a)" (gives' [Left ThreadKilled, Left UserInterrupt]) $ do
       var <- newEmptyMVar
       tId <- uninterruptibleMask $ \restore -> fork $ do
         result <- (Right <$> restore (throw UserInterrupt)) `E.catch` (pure . Left)
@@ -70,7 +70,7 @@ tests = toTestList
       v <- takeMVar var
       pure (v :: Either AsyncException ())
 
-  , (:[]) . expectFail $ testDejafuWithSettings defaultSettings "https://github.com/barrucadu/dejafu/issues/324 (b)" (gives' [Left ThreadKilled, Left UserInterrupt]) $ do
+  , djfu "https://github.com/barrucadu/dejafu/issues/324 (b)" (gives' [Left ThreadKilled, Left UserInterrupt]) $ do
       var <- newEmptyMVar
       tId <- uninterruptibleMask $ \restore -> fork $ do
         result <- (Right <$> restore (atomically $ throwSTM UserInterrupt)) `E.catch` (pure . Left)

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -376,11 +376,11 @@ genThreadAction = HGen.choice
   , D.CommitIORef <$> genThreadId <*> genIORefId
   , D.STM <$> genSmallList genTAction <*> genSmallList genThreadId
   , D.BlockedSTM <$> genSmallList genTAction
-  , D.ThrownSTM <$> genSmallList genTAction <*> HGen.maybe genMaskingState <*> HGen.bool
+  , D.ThrownSTM <$> genSmallList genTAction <*> HGen.maybe genMaskingState
   , pure D.Catching
   , pure D.PopCatching
-  , D.Throw <$> HGen.maybe genMaskingState <*> HGen.bool
-  , D.ThrowTo <$> genThreadId <*> HGen.maybe genMaskingState <*> HGen.bool
+  , D.Throw <$> HGen.maybe genMaskingState
+  , D.ThrowTo <$> genThreadId <*> HGen.maybe genMaskingState
   , D.BlockedThrowTo <$> genThreadId
   , D.SetMasking <$> HGen.bool <*> genMaskingState
   , D.ResetMasking <$> HGen.bool <*> genMaskingState

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -374,12 +374,12 @@ genThreadAction = HGen.choice
   , D.WriteIORef <$> genIORefId
   , D.CasIORef <$> genIORefId <*> HGen.bool
   , D.CommitIORef <$> genThreadId <*> genIORefId
-  , D.STM <$> genSmallList genTAction <*> genSmallList genThreadId
+  , D.STM <$> genSmallList genTAction <*> genSmallList genThreadId <*> HGen.maybe genMaskingState
   , D.BlockedSTM <$> genSmallList genTAction
   , pure D.Catching
   , pure D.PopCatching
-  , D.Throw <$> HGen.bool
-  , D.ThrowTo <$> genThreadId <*> HGen.bool
+  , D.Throw <$> HGen.maybe genMaskingState <*> HGen.bool
+  , D.ThrowTo <$> genThreadId <*> HGen.maybe genMaskingState <*> HGen.bool
   , D.BlockedThrowTo <$> genThreadId
   , D.SetMasking <$> HGen.bool <*> genMaskingState
   , D.ResetMasking <$> HGen.bool <*> genMaskingState

--- a/dejafu-tests/lib/Unit/Properties.hs
+++ b/dejafu-tests/lib/Unit/Properties.hs
@@ -374,8 +374,9 @@ genThreadAction = HGen.choice
   , D.WriteIORef <$> genIORefId
   , D.CasIORef <$> genIORefId <*> HGen.bool
   , D.CommitIORef <$> genThreadId <*> genIORefId
-  , D.STM <$> genSmallList genTAction <*> genSmallList genThreadId <*> HGen.maybe genMaskingState
+  , D.STM <$> genSmallList genTAction <*> genSmallList genThreadId
   , D.BlockedSTM <$> genSmallList genTAction
+  , D.ThrownSTM <$> genSmallList genTAction <*> HGen.maybe genMaskingState <*> HGen.bool
   , pure D.Catching
   , pure D.PopCatching
   , D.Throw <$> HGen.maybe genMaskingState <*> HGen.bool

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -19,7 +19,7 @@ Changed
 ~~~~~~~
 
 * ``Test.DejaFu.Types.ThreadAction``, ``Throw``, and ``ThrowTo`` now
-  include the resultant masking state.
+  include the resultant masking state, and no bool.
 
 Fixed
 ~~~~~

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,8 +6,11 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
-unreleased
-----------
+2.4.0.0 (2020-07-01)
+--------------------
+
+* Git: :tag:`dejafu-2.4.0.0`
+* Hackage: :hackage:`dejafu-2.4.0.0`
 
 Added
 ~~~~~

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -9,11 +9,17 @@ standard Haskell versioning scheme.
 unreleased
 ----------
 
+Added
+~~~~~
+
+* Thread action constructor for STM transactions which throw an
+  exception: ``Test.DejaFu.Types.ThreadAction`` ``ThrownSTM``
+
 Changed
 ~~~~~~~
 
-* ``Test.DejaFu.Types.ThreadAction``, ``STM``, ``Throw``, and
-  ``ThrowTo`` now include the resultant masking state.
+* ``Test.DejaFu.Types.ThreadAction``, ``Throw``, and ``ThrowTo`` now
+  include the resultant masking state.
 
 Fixed
 ~~~~~

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,6 +6,22 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+unreleased
+----------
+
+Changed
+~~~~~~~
+
+* ``Test.DejaFu.Types.ThreadAction``, ``STM``, ``Throw``, and
+  ``ThrowTo`` now include the resultant masking state.
+
+Fixed
+~~~~~
+
+* (:issue:`324`) Jumping out of a restored mask into an exception
+  handler now atomically restores the masking state.
+
+
 2.3.0.1 (2020-06-24)
 --------------------
 

--- a/dejafu/Test/DejaFu/Conc/Internal.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal.hs
@@ -513,7 +513,7 @@ stepThread _ _ _ _ tid (AAtom stm c) = synchronised $ \ctx@Context{..} -> do
     Success _ written val -> do
       let (threads', woken) = wake (OnTVar written) cThreads
       pure ( Succeeded ctx { cThreads = goto (c val) tid threads', cIdSource = idSource' }
-           , STM trace woken Nothing
+           , STM trace woken
            , effect
            )
     Retry touched -> do
@@ -523,7 +523,7 @@ stepThread _ _ _ _ tid (AAtom stm c) = synchronised $ \ctx@Context{..} -> do
            , effect
            )
     Exception e -> do
-      res' <- stepThrow (\ms _ -> STM trace [] ms) tid e ctx
+      res' <- stepThrow (ThrownSTM trace) tid e ctx
       pure $ case res' of
         (Succeeded ctx', act, effect') -> (Succeeded ctx' { cIdSource = idSource' }, act, effect')
         (Failed err, act, effect') -> (Failed err, act, effect')

--- a/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
@@ -4,7 +4,7 @@
 
 -- |
 -- Module      : Test.DejaFu.Conc.Internal.Threading
--- Copyright   : (c) 2016--2019 Michael Walker
+-- Copyright   : (c) 2016--2020 Michael Walker
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
@@ -70,18 +70,18 @@ thread ~= theblock = case (_blocking thread, theblock) of
 -- * Exceptions
 
 -- | An exception handler.
-data Handler n = forall e. Exception e => Handler (e -> MaskingState -> Action n)
+data Handler n = forall e. Exception e => Handler MaskingState (e -> Action n)
 
 -- | Propagate an exception upwards, finding the closest handler
 -- which can deal with it.
-propagate :: HasCallStack => SomeException -> ThreadId -> Threads n -> Maybe (Threads n)
+propagate :: HasCallStack => SomeException -> ThreadId -> Threads n -> Maybe (MaskingState, Threads n)
 propagate e tid threads = raise <$> propagate' handlers where
   handlers = _handlers (elookup tid threads)
 
-  raise (act, hs) = except act hs tid threads
+  raise (ms, act, hs) = (ms, except ms act hs tid threads)
 
   propagate' [] = Nothing
-  propagate' (Handler h:hs) = maybe (propagate' hs) (\act -> Just (act, hs)) $ h <$> fromException e
+  propagate' (Handler ms h:hs) = maybe (propagate' hs) (\act -> Just (ms, act, hs)) $ h <$> fromException e
 
 -- | Check if a thread can be interrupted by an exception.
 interruptible :: Thread n -> Bool
@@ -93,7 +93,7 @@ interruptible thread =
 catching :: (Exception e, HasCallStack) => (e -> Action n) -> ThreadId -> Threads n -> Threads n
 catching h = eadjust $ \thread ->
   let ms0 = _masking thread
-      h'  = Handler $ \e ms -> (if ms /= ms0 then AResetMask False False ms0 else id) (h e)
+      h'  = Handler ms0 h
   in thread { _handlers = h' : _handlers thread }
 
 -- | Remove the most recent exception handler.
@@ -102,9 +102,10 @@ uncatching = eadjust $ \thread ->
   thread { _handlers = etail (_handlers thread) }
 
 -- | Raise an exception in a thread.
-except :: HasCallStack => (MaskingState -> Action n) -> [Handler n] -> ThreadId -> Threads n -> Threads n
-except actf hs = eadjust $ \thread -> thread
-  { _continuation = actf (_masking thread)
+except :: HasCallStack => MaskingState -> Action n -> [Handler n] -> ThreadId -> Threads n -> Threads n
+except ms act hs = eadjust $ \thread -> thread
+  { _continuation = act
+  , _masking = ms
   , _handlers = hs
   , _blocking = Nothing
   }
@@ -112,6 +113,13 @@ except actf hs = eadjust $ \thread -> thread
 -- | Set the masking state of a thread.
 mask :: HasCallStack => MaskingState -> ThreadId -> Threads n -> Threads n
 mask ms = eadjust $ \thread -> thread { _masking = ms }
+
+-- | Check the masking state of a thread, returning @Nothing@ if it
+-- matches the given one.
+checkMask :: HasCallStack => MaskingState -> ThreadId -> Threads n -> Maybe MaskingState
+checkMask ms tid threads =
+  let ms0 = M.findWithDefault Unmasked tid (_masking <$> threads)
+  in if ms0 == ms then Nothing else Just ms0
 
 --------------------------------------------------------------------------------
 -- * Manipulating threads

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -136,7 +136,7 @@ tvarsOf act = tvarsRead act `S.union` tvarsWritten act
 tvarsWritten :: ThreadAction -> Set TVarId
 tvarsWritten act = S.fromList $ case act of
   STM trc _ -> concatMap tvarsOf' trc
-  ThrownSTM trc _ _ -> concatMap tvarsOf' trc
+  ThrownSTM trc _ -> concatMap tvarsOf' trc
   BlockedSTM trc -> concatMap tvarsOf' trc
   _ -> []
 
@@ -151,7 +151,7 @@ tvarsWritten act = S.fromList $ case act of
 tvarsRead :: ThreadAction -> Set TVarId
 tvarsRead act = S.fromList $ case act of
   STM trc _ -> concatMap tvarsOf' trc
-  ThrownSTM trc _ _ -> concatMap tvarsOf' trc
+  ThrownSTM trc _ -> concatMap tvarsOf' trc
   BlockedSTM trc -> concatMap tvarsOf' trc
   _ -> []
 
@@ -192,12 +192,12 @@ rewind (WriteIORef c) = WillWriteIORef c
 rewind (CasIORef c _) = WillCasIORef c
 rewind (CommitIORef t c) = WillCommitIORef t c
 rewind (STM _ _) = WillSTM
-rewind (ThrownSTM _ _ _) = WillSTM
+rewind (ThrownSTM _ _) = WillSTM
 rewind (BlockedSTM _) = WillSTM
 rewind Catching = WillCatching
 rewind PopCatching = WillPopCatching
-rewind (Throw _ _) = WillThrow
-rewind (ThrowTo t _ _) = WillThrowTo t
+rewind (Throw _) = WillThrow
+rewind (ThrowTo t _) = WillThrowTo t
 rewind (BlockedThrowTo t) = WillThrowTo t
 rewind (SetMasking b m) = WillSetMasking b m
 rewind (ResetMasking b m) = WillResetMasking b m
@@ -299,7 +299,7 @@ tidsOf (TakeMVar _ tids) = S.fromList tids
 tidsOf (TryTakeMVar _ _ tids) = S.fromList tids
 tidsOf (CommitIORef tid _) = S.singleton tid
 tidsOf (STM _ tids) = S.fromList tids
-tidsOf (ThrowTo tid _ _) = S.singleton tid
+tidsOf (ThrowTo tid _) = S.singleton tid
 tidsOf (BlockedThrowTo tid) = S.singleton tid
 tidsOf _ = S.empty
 
@@ -377,12 +377,12 @@ updateMaskState tid (Fork tid2) = \masks -> case M.lookup tid masks of
   Nothing -> masks
 updateMaskState tid (SetMasking   _ ms) = M.insert tid ms
 updateMaskState tid (ResetMasking _ ms) = M.insert tid ms
-updateMaskState tid (Throw _ True) = M.delete tid
-updateMaskState tid (Throw (Just ms) _) = M.insert tid ms
-updateMaskState tid (ThrownSTM _ _ True) = M.delete tid
-updateMaskState tid (ThrownSTM _ (Just ms) _) = M.insert tid ms
-updateMaskState _ (ThrowTo tid _ True) = M.delete tid
-updateMaskState _ (ThrowTo tid (Just ms) _) = M.insert tid ms
+updateMaskState tid (Throw Nothing) = M.delete tid
+updateMaskState tid (Throw (Just ms)) = M.insert tid ms
+updateMaskState tid (ThrownSTM _ Nothing) = M.delete tid
+updateMaskState tid (ThrownSTM _ (Just ms)) = M.insert tid ms
+updateMaskState _ (ThrowTo tid Nothing) = M.delete tid
+updateMaskState _ (ThrowTo tid (Just ms)) = M.insert tid ms
 updateMaskState tid Stop = M.delete tid
 updateMaskState _ _ = id
 

--- a/dejafu/Test/DejaFu/Internal.hs
+++ b/dejafu/Test/DejaFu/Internal.hs
@@ -135,7 +135,7 @@ tvarsOf act = tvarsRead act `S.union` tvarsWritten act
 -- didn't @retry@).
 tvarsWritten :: ThreadAction -> Set TVarId
 tvarsWritten act = S.fromList $ case act of
-  STM trc _ -> concatMap tvarsOf' trc
+  STM trc _ _ -> concatMap tvarsOf' trc
   BlockedSTM trc -> concatMap tvarsOf' trc
   _ -> []
 
@@ -149,7 +149,7 @@ tvarsWritten act = S.fromList $ case act of
 -- | Get the @TVar@s a transaction read from.
 tvarsRead :: ThreadAction -> Set TVarId
 tvarsRead act = S.fromList $ case act of
-  STM trc _ -> concatMap tvarsOf' trc
+  STM trc _ _ -> concatMap tvarsOf' trc
   BlockedSTM trc -> concatMap tvarsOf' trc
   _ -> []
 
@@ -189,12 +189,12 @@ rewind (ModIORefCas c) = WillModIORefCas c
 rewind (WriteIORef c) = WillWriteIORef c
 rewind (CasIORef c _) = WillCasIORef c
 rewind (CommitIORef t c) = WillCommitIORef t c
-rewind (STM _ _) = WillSTM
+rewind (STM _ _ _) = WillSTM
 rewind (BlockedSTM _) = WillSTM
 rewind Catching = WillCatching
 rewind PopCatching = WillPopCatching
-rewind (Throw _) = WillThrow
-rewind (ThrowTo t _) = WillThrowTo t
+rewind (Throw _ _) = WillThrow
+rewind (ThrowTo t _ _) = WillThrowTo t
 rewind (BlockedThrowTo t) = WillThrowTo t
 rewind (SetMasking b m) = WillSetMasking b m
 rewind (ResetMasking b m) = WillResetMasking b m
@@ -295,8 +295,8 @@ tidsOf (TryPutMVar _ _ tids) = S.fromList tids
 tidsOf (TakeMVar _ tids) = S.fromList tids
 tidsOf (TryTakeMVar _ _ tids) = S.fromList tids
 tidsOf (CommitIORef tid _) = S.singleton tid
-tidsOf (STM _ tids) = S.fromList tids
-tidsOf (ThrowTo tid _) = S.singleton tid
+tidsOf (STM _ tids _) = S.fromList tids
+tidsOf (ThrowTo tid _ _) = S.singleton tid
 tidsOf (BlockedThrowTo tid) = S.singleton tid
 tidsOf _ = S.empty
 
@@ -374,8 +374,11 @@ updateMaskState tid (Fork tid2) = \masks -> case M.lookup tid masks of
   Nothing -> masks
 updateMaskState tid (SetMasking   _ ms) = M.insert tid ms
 updateMaskState tid (ResetMasking _ ms) = M.insert tid ms
-updateMaskState tid (Throw True) = M.delete tid
-updateMaskState _ (ThrowTo tid True) = M.delete tid
+updateMaskState tid (Throw _ True) = M.delete tid
+updateMaskState tid (Throw (Just ms) _) = M.insert tid ms
+updateMaskState _ (ThrowTo tid _ True) = M.delete tid
+updateMaskState _ (ThrowTo tid (Just ms) _) = M.insert tid ms
+updateMaskState tid (STM _ _ (Just ms)) = M.insert tid ms
 updateMaskState tid Stop = M.delete tid
 updateMaskState _ _ = id
 

--- a/dejafu/Test/DejaFu/SCT/Internal.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal.hs
@@ -397,8 +397,8 @@ renumber memtype tid0 crid0 = snd . mapAccumL go (I.empty, tid0, I.empty, crid0)
     (s, WriteIORef (renumbered cridmap old))
   updateAction s@(_, _, cridmap, _) (CasIORef old b) =
     (s, CasIORef (renumbered cridmap old) b)
-  updateAction s@(tidmap, _, _, _) (STM tas olds ms) =
-    (s, STM tas (map (renumbered tidmap) olds) ms)
+  updateAction s@(tidmap, _, _, _) (STM tas olds) =
+    (s, STM tas (map (renumbered tidmap) olds))
   updateAction s@(tidmap, _, _, _) (ThrowTo old ms b) =
     (s, ThrowTo (renumbered tidmap old) ms b)
   updateAction s@(tidmap, _, _, _) (BlockedThrowTo old) =

--- a/dejafu/Test/DejaFu/SCT/Internal.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal.hs
@@ -5,7 +5,7 @@
 
 -- |
 -- Module      : Test.DejaFu.SCT.Internal
--- Copyright   : (c) 2018--2019 Michael Walker
+-- Copyright   : (c) 2018--2020 Michael Walker
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
@@ -397,10 +397,10 @@ renumber memtype tid0 crid0 = snd . mapAccumL go (I.empty, tid0, I.empty, crid0)
     (s, WriteIORef (renumbered cridmap old))
   updateAction s@(_, _, cridmap, _) (CasIORef old b) =
     (s, CasIORef (renumbered cridmap old) b)
-  updateAction s@(tidmap, _, _, _) (STM tas olds) =
-    (s, STM tas (map (renumbered tidmap) olds))
-  updateAction s@(tidmap, _, _, _) (ThrowTo old b) =
-    (s, ThrowTo (renumbered tidmap old) b)
+  updateAction s@(tidmap, _, _, _) (STM tas olds ms) =
+    (s, STM tas (map (renumbered tidmap) olds) ms)
+  updateAction s@(tidmap, _, _, _) (ThrowTo old ms b) =
+    (s, ThrowTo (renumbered tidmap old) ms b)
   updateAction s@(tidmap, _, _, _) (BlockedThrowTo old) =
     (s, BlockedThrowTo (renumbered tidmap old))
   updateAction s act = (s, act)

--- a/dejafu/Test/DejaFu/SCT/Internal.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal.hs
@@ -399,8 +399,8 @@ renumber memtype tid0 crid0 = snd . mapAccumL go (I.empty, tid0, I.empty, crid0)
     (s, CasIORef (renumbered cridmap old) b)
   updateAction s@(tidmap, _, _, _) (STM tas olds) =
     (s, STM tas (map (renumbered tidmap) olds))
-  updateAction s@(tidmap, _, _, _) (ThrowTo old ms b) =
-    (s, ThrowTo (renumbered tidmap old) ms b)
+  updateAction s@(tidmap, _, _, _) (ThrowTo old ms) =
+    (s, ThrowTo (renumbered tidmap old) ms)
   updateAction s@(tidmap, _, _, _) (BlockedThrowTo old) =
     (s, BlockedThrowTo (renumbered tidmap old))
   updateAction s act = (s, act)

--- a/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
+++ b/dejafu/Test/DejaFu/SCT/Internal/DPOR.hs
@@ -5,7 +5,7 @@
 
 -- |
 -- Module      : Test.DejaFu.SCT.Internal.DPOR
--- Copyright   : (c) 2015--2018 Michael Walker
+-- Copyright   : (c) 2015--2020 Michael Walker
 -- License     : MIT
 -- Maintainer  : Michael Walker <mike@barrucadu.co.uk>
 -- Stability   : experimental
@@ -565,7 +565,7 @@ independent safeIO ds t1 a1 t2 a2
     -- :(
     --
     -- See #191 / #190
-    check _ (ThrowTo t _) tid _ | t == tid = True
+    check _ (ThrowTo t _ _) tid _ | t == tid = True
     check _ (BlockedThrowTo t) tid _ | t == tid = True
     -- can't re-order an unsynchronised write with something which synchronises that IORef.
     check _ (simplifyAction -> UnsynchronisedWrite r) _ (simplifyAction -> a) | synchronises a r = True
@@ -582,17 +582,17 @@ dependent safeIO ds t1 a1 t2 a2 = case (a1, a2) of
   -- actually blocked. 'dependent'' has to assume that all
   -- potentially-blocking operations can block, and so is more
   -- pessimistic in this case.
-  (ThrowTo t _, ThrowTo u _)
+  (ThrowTo t _ _, ThrowTo u _ _)
     | t == t2 && u == t1 -> canInterrupt ds t1 a1 || canInterrupt ds t2 a2
-  (ThrowTo t _, _) | t == t2 -> canInterrupt ds t2 a2 && a2 /= Stop
-  (_, ThrowTo t _) | t == t1 -> canInterrupt ds t1 a1 && a1 /= Stop
+  (ThrowTo t _ _, _) | t == t2 -> canInterrupt ds t2 a2 && a2 /= Stop
+  (_, ThrowTo t _ _) | t == t1 -> canInterrupt ds t1 a1 && a1 /= Stop
 
   -- Dependency of STM transactions can be /greatly/ improved here, as
   -- the 'Lookahead' does not know which @TVar@s will be touched, and
   -- so has to assume all transactions are dependent.
-  (STM _ _, STM _ _)           -> checkSTM
-  (STM _ _, BlockedSTM _)      -> checkSTM
-  (BlockedSTM _, STM _ _)      -> checkSTM
+  (STM _ _ _, STM _ _ _)       -> checkSTM
+  (STM _ _ _, BlockedSTM _)    -> checkSTM
+  (BlockedSTM _, STM _ _ _)    -> checkSTM
   (BlockedSTM _, BlockedSTM _) -> checkSTM
 
   _ -> dependent' safeIO ds t1 a1 t2 (rewind a2)
@@ -617,13 +617,13 @@ dependent' safeIO ds t1 a1 t2 l2 = case (a1, l2) of
   -- thread and if the actions can be interrupted. We can also
   -- slightly improve on that by not considering interrupting the
   -- normal termination of a thread: it doesn't make a difference.
-  (ThrowTo t _, WillThrowTo u)
+  (ThrowTo t _ _, WillThrowTo u)
     | t == t2 && u == t1 -> canInterrupt ds t1 a1 || canInterruptL ds t2 l2
-  (ThrowTo t _, _)   | t == t2 -> canInterruptL ds t2 l2 && l2 /= WillStop
+  (ThrowTo t _ _, _)   | t == t2 -> canInterruptL ds t2 l2 && l2 /= WillStop
   (_, WillThrowTo t) | t == t1 -> canInterrupt  ds t1 a1 && a1 /= Stop
 
   -- Another worst-case: assume all STM is dependent.
-  (STM _ _, WillSTM) -> True
+  (STM _ _ _, WillSTM) -> True
   (BlockedSTM _, WillSTM) -> True
 
   -- the number of capabilities is essentially a global shared

--- a/dejafu/Test/DejaFu/Types.hs
+++ b/dejafu/Test/DejaFu/Types.hs
@@ -289,24 +289,23 @@ data ThreadAction =
   | STM [TAction] [ThreadId]
   -- ^ An STM transaction was executed, possibly waking up some
   -- threads.
-  | ThrownSTM [TAction] (Maybe MaskingState) Bool
+  | ThrownSTM [TAction] (Maybe MaskingState)
   -- ^ An STM transaction threw an exception.  Give the resultant
-  -- masking state after jumping to the exception handler (if it
-  -- changed).  If the 'Bool' is @True@, then this killed the thread.
+  -- masking state after jumping to the exception handler (if the
+  -- thread is still alive).
   | BlockedSTM [TAction]
   -- ^ Got blocked in an STM transaction.
   | Catching
   -- ^ Register a new exception handler
   | PopCatching
   -- ^ Pop the innermost exception handler from the stack.
-  | Throw (Maybe MaskingState) Bool
+  | Throw (Maybe MaskingState)
   -- ^ Throw an exception, and give the resultant masking state after
-  -- jumping to the exception handler (if it changed).  If the 'Bool'
-  -- is @True@, then this killed the thread.
-  | ThrowTo ThreadId (Maybe MaskingState) Bool
+  -- jumping to the exception handler (if the thread is still alive).
+  | ThrowTo ThreadId (Maybe MaskingState)
   -- ^ Throw an exception to a thread, and give the resultant masking
-  -- state after jumping to the exception handler (if it changed).  If
-  -- the 'Bool' is @True@, then this killed the thread.
+  -- state after jumping to the exception handler (if the thread is
+  -- still alive).
   | BlockedThrowTo ThreadId
   -- ^ Get blocked on a 'throwTo'.
   | SetMasking Bool MaskingState
@@ -360,15 +359,15 @@ instance NFData ThreadAction where
   rnf (CasIORef c b) = rnf (c, b)
   rnf (CommitIORef t c) = rnf (t, c)
   rnf (STM as ts) = rnf (as, ts)
-  rnf (ThrownSTM as (Just m) b) = m `seq` rnf (as, b)
-  rnf (ThrownSTM as Nothing b) = rnf (as, b)
+  rnf (ThrownSTM as (Just m)) = m `seq` rnf as
+  rnf (ThrownSTM as Nothing) = rnf as
   rnf (BlockedSTM as) = rnf as
   rnf Catching = ()
   rnf PopCatching = ()
-  rnf (Throw (Just m) b) = m `seq` rnf b
-  rnf (Throw Nothing b) = rnf b
-  rnf (ThrowTo t (Just m) b) = m `seq` rnf (t, b)
-  rnf (ThrowTo t Nothing b) = rnf (t, b)
+  rnf (Throw (Just m)) = m `seq` ()
+  rnf (Throw Nothing) = ()
+  rnf (ThrowTo t (Just m)) = m `seq` rnf t
+  rnf (ThrowTo t Nothing) = rnf t
   rnf (BlockedThrowTo t) = rnf t
   rnf (SetMasking b m) = rnf (b, show m)
   rnf (ResetMasking b m) = rnf (b, show m)

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             2.3.0.1
+version:             2.4.0.0
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-2.3.0.1
+  tag:      dejafu-2.4.0.0
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,9 +28,9 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.11.0.0", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "2.3.0.1",  "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "2.0.0.3",  "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "2.0.0.5",  "Déjà Fu support for the tasty test framework"
+   ":hackage:`dejafu`",       "2.4.0.0",  "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "2.0.0.4",  "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "2.0.0.6",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+2.0.0.4 (2020-07-01)
+--------------------
+
+* Git: :tag:`hunit-dejafu-2.0.0.4`
+* Hackage: :hackage:`hunit-dejafu-2.0.0.4`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <2.5
+
+
 2.0.0.3 (2020-05-10)
 --------------------
 

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             2.0.0.3
+version:             2.0.0.4
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-2.0.0.3
+  tag:      hunit-dejafu-2.0.0.4
 
 library
   exposed-modules:     Test.HUnit.DejaFu
@@ -38,7 +38,7 @@ library
   -- other-extensions:    
   build-depends:       base       >=4.9 && <5
                      , exceptions >=0.7 && <0.11
-                     , dejafu     >=2.0 && <2.4
+                     , dejafu     >=2.0 && <2.5
                      , HUnit      >=1.3.1 && <1.7
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -6,6 +6,18 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+2.0.0.6 (2020-07-01)
+--------------------
+
+* Git: :tag:`tasty-dejafu-2.0.0.6`
+* Hackage: :hackage:`tasty-dejafu-2.0.0.6`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`dejafu` is <2.5.
+
+
 2.0.0.5 (2020-06-24)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             2.0.0.5
+version:             2.0.0.6
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,14 +30,14 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-2.0.0.5
+  tag:      tasty-dejafu-2.0.0.6
 
 library
   exposed-modules:     Test.Tasty.DejaFu
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base   >=4.9  && <5
-                     , dejafu >=2.0  && <2.4
+                     , dejafu >=2.0  && <2.5
                      , random >=1.0  && <1.3
                      , tagged >=0.8  && <0.9
                      , tasty  >=0.10 && <1.4


### PR DESCRIPTION
## Summary

Previously, dejafu did not atomically restore the masking state of a thread when jumping to an exception handler.  This opens a possibility of a race with another thread calling `throwTo`, and this is a race which GHC does not do!

This PR makes the restoration of the masking state atomic, changes `Throw` and `ThrowTo` to report the new masking state (if it changed), and adds a new `ThrownSTM` action.

**Related issues:** fixes #324

## Checklist

- [x] Add new tests to dejafu-tests

## Benchmark results (for performance issues)

**Before:**

```
$ stack exec -- dejafu-tests +RTS -s

 135,743,041,632 bytes allocated in the heap
  22,764,435,640 bytes copied during GC
      13,045,840 bytes maximum residency (4468 sample(s))
          96,712 bytes maximum slop
              12 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     126630 colls,     0 par   14.163s  14.146s     0.0001s    0.0008s
  Gen  1      4468 colls,     0 par    7.858s   7.865s     0.0018s    0.0162s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   70.529s  ( 67.576s elapsed)
  GC      time   22.021s  ( 22.011s elapsed)
  EXIT    time    0.000s  (  0.002s elapsed)
  Total   time   92.550s  ( 89.590s elapsed)

  Alloc rate    1,924,643,085 bytes per MUT second

  Productivity  76.2% of total user, 75.4% of total elapsed
```

**After:** (with the two new tests commented out)

```
$ stack exec -- dejafu-tests +RTS -s

 138,271,002,848 bytes allocated in the heap
  23,508,977,296 bytes copied during GC
      13,335,744 bytes maximum residency (4686 sample(s))
         128,928 bytes maximum slop
              12 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     128854 colls,     0 par   14.606s  14.577s     0.0001s    0.0008s
  Gen  1      4686 colls,     0 par    7.999s   7.993s     0.0017s    0.0146s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   71.915s  ( 68.950s elapsed)
  GC      time   22.605s  ( 22.571s elapsed)
  EXIT    time    0.000s  (  0.010s elapsed)
  Total   time   94.521s  ( 91.530s elapsed)

  Alloc rate    1,922,689,157 bytes per MUT second

  Productivity  76.1% of total user, 75.3% of total elapsed
```

I was worried the extra allocation may be a problem, but it's fine.