### PR TITLE
Support tasty-1.4

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,7 +48,7 @@ There are a few different packages under the Déjà Fu umbrella:
 | [concurrency][h:conc]    | 1.11.0.0 | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 2.4.0.0  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.4  | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 2.0.0.6  | Deja Fu support for the Tasty test framework. |
+| [tasty-dejafu][h:tasty]  | 2.0.0.7  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/dejafu-tests/exe/MainBench.hs
+++ b/dejafu-tests/exe/MainBench.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Main where
 
 import qualified Criterion.Main       as C
@@ -13,10 +15,17 @@ main = C.defaultMain (T.foldTestTree mkBench mempty tests)
 
 -- | Turn a test tree into a list of benchmarks.
 mkBench :: T.TreeFold [C.Benchmark]
+#if MIN_VERSION_tasty(1,4,0)
+mkBench = T.trivialFold
+  { T.foldSingle = \opts lbl t -> [C.bench lbl (benchTest opts t)]
+  , T.foldGroup = \_ lbl bs -> [C.bgroup lbl bs]
+  }
+#else
 mkBench = T.trivialFold
   { T.foldSingle = \opts lbl t -> [C.bench lbl (benchTest opts t)]
   , T.foldGroup = \lbl bs -> [C.bgroup lbl bs]
   }
+#endif
 
 -- | Turn a test into a benchmark.
 benchTest :: T.IsTest t => T.OptionSet -> t -> C.Benchmarkable

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -30,7 +30,7 @@ There are a few different packages under the Déjà Fu umbrella:
    ":hackage:`concurrency`",  "1.11.0.0", "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "2.4.0.0",  "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.4",  "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "2.0.0.6",  "Déjà Fu support for the tasty test framework"
+   ":hackage:`tasty-dejafu`", "2.0.0.7",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+2.0.0.7 (2020-12-27)
+--------------------
+
+* Git: :tag:`tasty-dejafu-2.0.0.7`
+* Hackage: :hackage:`tasty-dejafu-2.0.0.7`
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -6,6 +6,16 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`tasty` is <1.5.
+
+
 2.0.0.6 (2020-07-01)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -40,6 +40,6 @@ library
                      , dejafu >=2.0  && <2.5
                      , random >=1.0  && <1.3
                      , tagged >=0.8  && <0.9
-                     , tasty  >=0.10 && <1.4
+                     , tasty  >=0.10 && <1.5
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             2.0.0.6
+version:             2.0.0.7
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-2.0.0.6
+  tag:      tasty-dejafu-2.0.0.7
 
 library
   exposed-modules:     Test.Tasty.DejaFu


### PR DESCRIPTION
## Summary

Bump tasty-dejafu's upper bound on tasty to 1.5, and fix an incompatibility in the benchmark suite.
