### PR TITLE
Correctly reset new TVar values when restoring snapshots 

### DIFF
--- a/dejafu-tests/lib/Integration/Regressions.hs
+++ b/dejafu-tests/lib/Integration/Regressions.hs
@@ -80,7 +80,7 @@ tests = toTestList
       v <- takeMVar var
       pure (v :: Either AsyncException ())
 
-  , (:[]) . expectFail $ testDejafuWithSettings (fromWayAndMemType (randomly (mkStdGen 0) 10) defaultMemType) "https://github.com/barrucadu/dejafu/issues/331" (gives' [1]) $
+  , (:[]) . testDejafuWithSettings (fromWayAndMemType (randomly (mkStdGen 0) 10) defaultMemType) "https://github.com/barrucadu/dejafu/issues/331" (gives' [1]) $
       withSetup (atomically $ newTVar (0::Int)) $ \tvar -> atomically $ do
         modifyTVar tvar (+1)
         readTVar tvar

--- a/dejafu-tests/lib/Integration/Regressions.hs
+++ b/dejafu-tests/lib/Integration/Regressions.hs
@@ -7,6 +7,7 @@ import           Test.DejaFu               (exceptionsAlways, gives')
 import           Control.Concurrent.Classy
 import           Control.Exception         (AsyncException(..))
 import qualified Control.Monad.Catch       as E
+import           System.Random             (mkStdGen)
 
 import           Common
 
@@ -78,4 +79,9 @@ tests = toTestList
       killThread tId
       v <- takeMVar var
       pure (v :: Either AsyncException ())
+
+  , (:[]) . expectFail $ testDejafuWithSettings (fromWayAndMemType (randomly (mkStdGen 0) 10) defaultMemType) "https://github.com/barrucadu/dejafu/issues/331" (gives' [1]) $
+      withSetup (atomically $ newTVar (0::Int)) $ \tvar -> atomically $ do
+        modifyTVar tvar (+1)
+        readTVar tvar
   ]

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,6 +6,17 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+
+unreleased
+----------
+
+Fixed
+~~~~~
+
+* (:issue:`331`) Initial TVar values from setup actions are now
+  restored for subsequent executions.
+
+
 2.4.0.0 (2020-07-01)
 --------------------
 


### PR DESCRIPTION
## Summary

Previously, the setup action for an STM transaction was just the transaction itself.  This works fine for replacing `SWrite`s, but not for `SNew`s, as it just creates a *new* new TVar and doesn't reset the value of the existing one.

This PR records an explicit "effect" of STM transactions to be used in snapshots, in the same way as non-STM effects are replayed when running a snapshot.

This adds the overhead of constructing the effect to every STM transaction, which I worried would be a large cost; but it turns out that the overhead is negligible.

**Related issues:** fixes #331 
