### PR TITLE
Add GHC 8.10 to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
           - lts-12.0 # ghc-8.4
           - lts-13.3 # ghc-8.6
           - lts-15.0 # ghc-8.8
+          - lts-17.0 # ghc-8.10
 
     steps:
       - name: 'https://github.com/mstksg/setup-stack/issues/13'


### PR DESCRIPTION
Add GHC 8.10, which got missed out, to CI.

I might want to remove some of the older versions.  The docs say the latest 4 versions of GHC are supported, which is now 9.0, 8.10, 8.1, and 8.6.  I'll have to look into what benefits dropping 8.4, 8.2, and 8.0 would bring.  A reduction in CPP, probably.  Code improvements, maybe?