### PR TITLE
Remove references to freenode in READMEs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,10 +42,10 @@ There are a few different packages under the Déjà Fu umbrella:
 
 |   | Version | Summary |
 | - | ------- | ------- |
-| [concurrency][h:conc]    | 1.11.0.1 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 2.4.0.2  | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 2.0.0.4  | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 2.0.0.7  | Deja Fu support for the Tasty test framework. |
+| [concurrency][h:conc]    | 1.11.0.2 | Typeclasses, functions, and data types for concurrency and STM. |
+| [dejafu][h:dejafu]       | 2.4.0.3  | Systematic testing for Haskell concurrency. |
+| [hunit-dejafu][h:hunit]  | 2.0.0.5  | Deja Fu support for the HUnit test framework. |
+| [tasty-dejafu][h:tasty]  | 2.0.0.8  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -6,6 +6,19 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+
+1.11.0.2 (2021-08-15)
+---------------------
+
+* Git: :tag:`concurrency-1.11.0.2`
+* Hackage: :hackage:`concurrency-1.11.0.2`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* Remove reference to freenode in README.
+
+
 1.11.0.1 (2021-03-14)
 ---------------------
 

--- a/concurrency/README.markdown
+++ b/concurrency/README.markdown
@@ -55,8 +55,8 @@ Contributing
 
 Bug reports, pull requests, and comments are very welcome!
 
-Feel free to contact me on GitHub, through IRC (#haskell on freenode),
-or email (mike@barrucadu.co.uk).
+Feel free to contact me on GitHub, through IRC (#haskell on
+libera.chat), or email (mike@barrucadu.co.uk).
 
 [async]:   https://hackage.haskell.org/package/async
 [parconc]: http://chimera.labs.oreilly.com/books/1230000000929

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                concurrency
-version:             1.11.0.1
+version:             1.11.0.2
 synopsis:            Typeclasses, functions, and data types for concurrency and STM.
 
 description:
@@ -32,7 +32,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      concurrency-1.11.0.1
+  tag:      concurrency-1.11.0.2
 
 library
   exposed-modules:     Control.Monad.Conc.Class

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+2.4.0.3 (2021-08-15)
+--------------------
+
+* Git: :tag:`dejafu-2.4.0.3`
+* Hackage: :hackage:`dejafu-2.4.0.3`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* Remove reference to freenode in README.
+
+
 2.4.0.2 (2021-03-14)
 --------------------
 

--- a/dejafu/README.markdown
+++ b/dejafu/README.markdown
@@ -131,5 +131,5 @@ Contributing
 
 Bug reports, pull requests, and comments are very welcome!
 
-Feel free to contact me on GitHub, through IRC (#haskell on freenode),
-or email (mike@barrucadu.co.uk).
+Feel free to contact me on GitHub, through IRC (#haskell on
+libera.chat), or email (mike@barrucadu.co.uk).

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             2.4.0.2
+version:             2.4.0.3
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-2.4.0.2
+  tag:      dejafu-2.4.0.3
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,10 +27,10 @@ There are a few different packages under the Déjà Fu umbrella:
 .. csv-table::
    :header: "Package", "Version", "Summary"
 
-   ":hackage:`concurrency`",  "1.11.0.1", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "2.4.0.2",  "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "2.0.0.4",  "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "2.0.0.7",  "Déjà Fu support for the tasty test framework"
+   ":hackage:`concurrency`",  "1.11.0.2", "Typeclasses, functions, and data types for concurrency and STM"
+   ":hackage:`dejafu`",       "2.4.0.3",  "Systematic testing for Haskell concurrency"
+   ":hackage:`hunit-dejafu`", "2.0.0.5",  "Déjà Fu support for the HUnit test framework"
+   ":hackage:`tasty-dejafu`", "2.0.0.8",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+2.0.0.5 (2021-08-15)
+--------------------
+
+* Git: :tag:`hunit-dejafu-2.0.0.5`
+* Hackage: :hackage:`hunit-dejafu-2.0.0.5`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* Remove reference to freenode in README.
+
+
 2.0.0.4 (2020-07-01)
 --------------------
 

--- a/hunit-dejafu/README.markdown
+++ b/hunit-dejafu/README.markdown
@@ -10,8 +10,8 @@ Contributing
 
 Bug reports, pull requests, and comments are very welcome!
 
-Feel free to contact me on GitHub, through IRC (#haskell on freenode),
-or email (mike@barrucadu.co.uk).
+Feel free to contact me on GitHub, through IRC (#haskell on
+libera.chat), or email (mike@barrucadu.co.uk).
 
 [dejafu]: https://hackage.haskell.org/package/dejafu
 [HUnit]:  https://hackage.haskell.org/package/HUnit

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             2.0.0.4
+version:             2.0.0.5
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-2.0.0.4
+  tag:      hunit-dejafu-2.0.0.5
 
 library
   exposed-modules:     Test.HUnit.DejaFu

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,18 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+2.0.0.8 (2021-08-15)
+--------------------
+
+* Git: :tag:`tasty-dejafu-2.0.0.8`
+* Hackage: :hackage:`tasty-dejafu-2.0.0.8`
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* Remove reference to freenode from README.
+
+
 2.0.0.7 (2020-12-27)
 --------------------
 

--- a/tasty-dejafu/README.markdown
+++ b/tasty-dejafu/README.markdown
@@ -10,8 +10,8 @@ Contributing
 
 Bug reports, pull requests, and comments are very welcome!
 
-Feel free to contact me on GitHub, through IRC (#haskell on freenode),
-or email (mike@barrucadu.co.uk).
+Feel free to contact me on GitHub, through IRC (#haskell on
+libera.chat), or email (mike@barrucadu.co.uk).
 
 [dejafu]: https://hackage.haskell.org/package/dejafu
 [tasty]:  https://hackage.haskell.org/package/tasty

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             2.0.0.7
+version:             2.0.0.8
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-2.0.0.7
+  tag:      tasty-dejafu-2.0.0.8
 
 library
   exposed-modules:     Test.Tasty.DejaFu


### PR DESCRIPTION
Change everything to libera.chat and make patch releases so that the new READMEs propagate to hackage.