### PR TITLE
Add LTS-19.0 to build matrix & supported GHC versions doc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
           - lts-13.3 # ghc-8.6
           - lts-15.0 # ghc-8.8
           - lts-17.0 # ghc-8.10
+          - lts-19.0 # ghc-9.0
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -51,3 +51,8 @@
 - ignore: {name: "Alternative law, right identity", within: Examples.ClassLaws}
 - ignore: {name: "Alternative law, left identity", within: Examples.ClassLaws}
 - ignore: {name: "Monoid law, right identity", within: Unit.Properties}
+
+# Not implemented
+- ignore: {name: "Use newEmptyTMVarIO"}
+- ignore: {name: "Use newTMVarIO"}
+- ignore: {name: "Use newTVarIO"}

--- a/concurrency/Control/Concurrent/Classy/Async.hs
+++ b/concurrency/Control/Concurrent/Classy/Async.hs
@@ -754,7 +754,7 @@ forConcurrently_ = flip mapConcurrently_
 --
 -- @since 1.1.2.0
 replicateConcurrently :: MonadConc m => Int -> m a -> m [a]
-replicateConcurrently i = runConcurrently . sequenceA . replicate i . Concurrently
+replicateConcurrently i = runConcurrently . replicateM i . Concurrently
 
 -- | 'replicateConcurrently_' is 'replicateConcurrently' with the
 -- return values discarded.

--- a/dejafu-tests/lib/Examples/ParMonad.hs
+++ b/dejafu-tests/lib/Examples/ParMonad.hs
@@ -16,10 +16,9 @@ tests = toTestList
 
 parFilter :: (MonadConc m, MonadIO m) => m Bool
 parFilter = do
-    let p x = x `mod` 2 == 0
     let xs = [0..1] :: [Int]
-    s <- Par.runParIO $ parfilter p xs
-    pure (s == filter p xs)
+    s <- Par.runParIO $ parfilter even xs
+    pure (s == filter even xs)
   where
     parfilter _ []  = pure []
     parfilter f [x] = pure [x | f x]

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,6 +6,14 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* Update doctest examples in `Test.DejaFu`.
+
 
 2.4.0.3 (2021-08-15)
 --------------------

--- a/dejafu/Test/DejaFu.hs
+++ b/dejafu/Test/DejaFu.hs
@@ -491,7 +491,7 @@ dejafu = dejafuWithSettings defaultSettings
 -- [fail] Randomly!
 --     "hello" S0----S1--S0--
 -- <BLANKLINE>
---     "world" S0----S2--S1-S0--
+--     "world" S0---P2--S0--
 -- False
 --
 -- @since 2.1.0.0
@@ -517,7 +517,7 @@ dejafuWay way = dejafuWithSettings . fromWayAndMemType way
 -- [fail] Randomly!
 --     "hello" S0----S1--S0--
 -- <BLANKLINE>
---     "world" S0----S2--S1-S0--
+--     "world" S0---P2--S0--
 -- False
 --
 -- @since 2.1.0.0

--- a/dejafu/Test/DejaFu/Conc.hs
+++ b/dejafu/Test/DejaFu/Conc.hs
@@ -57,6 +57,7 @@ module Test.DejaFu.Conc
   ) where
 
 import           Control.Exception                 (MaskingState(..))
+import           Control.Monad                     (void)
 
 import           Test.DejaFu.Conc.Internal.Common
 import           Test.DejaFu.Conc.Internal.Program
@@ -164,7 +165,7 @@ withSetupAndTeardown setup teardown =
 --
 -- @since 2.0.0.0
 registerInvariant :: Invariant n a -> Program Basic n ()
-registerInvariant inv = ModelConc (\c -> ANewInvariant (() <$ inv) (c ()))
+registerInvariant inv = ModelConc (\c -> ANewInvariant (void inv) (c ()))
 
 -- | Read the content of an @IORef@.
 --

--- a/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Threading.hs
@@ -81,7 +81,7 @@ propagate e tid threads = raise <$> propagate' handlers where
   raise (ms, act, hs) = except ms act hs tid threads
 
   propagate' [] = Nothing
-  propagate' (Handler ms h:hs) = maybe (propagate' hs) (\act -> Just (ms, act, hs)) $ h <$> fromException e
+  propagate' (Handler ms h:hs) = maybe (propagate' hs) ((\act -> Just (ms, act, hs)) . h) (fromException e)
 
 -- | Check if a thread can be interrupted by an exception.
 interruptible :: Thread n -> Bool

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -8,7 +8,7 @@ currently supported versions are:
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
-   "9.0",  "",         "4.15.0.0"
+   "9.0",  "LTS 19.0", "4.15.0.0"
    "8.10", "LTS 17.0", "4.14.1.0"
    "8.8",  "LTS 15.0", "4.13.0.0"
    "8.6",  "LTS 13.0", "4.12.0.0"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.0
+resolver: nightly-2022-07-01
 
 packages:
 - concurrency


### PR DESCRIPTION
There should be a patch release of dejafu after this, since the
doctest examples changed.

Also, need to bump to a nightly snapshot in `stack.yaml` for
stylish-haskell, which looks to have skipped GHC 9.0 support.

In principle, we could now drop support for GHC 8.0, 8.2, and 8.4, but
supporting those isn't causing any problems yet.