### PR TITLE
Bump upper bound on leancheck to <2

### DIFF
--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -13,6 +13,7 @@ Miscellaneous
 ~~~~~~~~~~~~~
 
 * Update doctest examples in `Test.DejaFu`.
+* The upper bound on :hackage:`leancheck` is <2.
 
 
 2.4.0.3 (2021-08-15)

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -64,7 +64,7 @@ library
                      , contravariant     >=1.2 && <1.6
                      , deepseq           >=1.1 && <2
                      , exceptions        >=0.7 && <0.11
-                     , leancheck         >=0.6 && <0.10
+                     , leancheck         >=0.6 && <2
                      , profunctors       >=4.0 && <6
                      , random            >=1.0 && <1.3
                      , transformers      >=0.5 && <0.6


### PR DESCRIPTION
https://github.com/commercialhaskell/stackage/issues/6693