### PR TITLE
Add GHC 9.2 to supported versions list

### DIFF
--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -8,6 +8,7 @@ currently supported versions are:
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
+   "9.2",  "",         "4.16.0.0"
    "9.0",  "LTS 19.0", "4.15.0.0"
    "8.10", "LTS 17.0", "4.14.1.0"
    "8.8",  "LTS 15.0", "4.13.0.0"


### PR DESCRIPTION
No bounds need changing for this, so no release is needed.