### PR TITLE
Release dejafu-2.4.0.4

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.11.0.2 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 2.4.0.3  | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 2.4.0.4  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.5  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 2.0.0.8  | Deja Fu support for the Tasty test framework. |
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -6,8 +6,11 @@ standard Haskell versioning scheme.
 
 .. _PVP: https://pvp.haskell.org/
 
-unreleased
-----------
+2.4.0.4 (2022-08-22)
+--------------------
+
+* Git: :tag:`dejafu-2.4.0.4`
+* Hackage: :hackage:`dejafu-2.4.0.4`
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             2.4.0.3
+version:             2.4.0.4
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-2.4.0.3
+  tag:      dejafu-2.4.0.4
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.11.0.2", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "2.4.0.3",  "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "2.4.0.4",  "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.5",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "2.0.0.8",  "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
- Updates doctest examples
- Increases leancheck upper bound