### PR TITLE
Remove inaccurate comments about sharing

### DIFF
--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,6 +7,16 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Fixed
+~~~~~
+
+* Remove inaccurate comment about ```Test.HUnit.DejaFu.testDejafus``
+  sharing work.
+
+
 2.0.0.5 (2021-08-15)
 --------------------
 

--- a/hunit-dejafu/Test/HUnit/DejaFu.hs
+++ b/hunit-dejafu/Test/HUnit/DejaFu.hs
@@ -196,8 +196,7 @@ testDejafuWithSettings :: Show b
 testDejafuWithSettings settings name p = testDejafusWithSettings settings [(name, p)]
 
 -- | Variant of 'testDejafu' which takes a collection of predicates to
--- test. This will share work between the predicates, rather than
--- running the concurrent computation many times for each predicate.
+-- test.
 --
 -- @since 2.0.0.0
 testDejafus :: Show b

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,16 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Fixed
+~~~~~
+
+* Remove inaccurate comment about ```Test.Tasty.DejaFu.testDejafus``
+  sharing work.
+
+
 2.0.0.8 (2021-08-15)
 --------------------
 

--- a/tasty-dejafu/Test/Tasty/DejaFu.hs
+++ b/tasty-dejafu/Test/Tasty/DejaFu.hs
@@ -229,8 +229,7 @@ testDejafuWithSettings :: Show b
 testDejafuWithSettings settings name p = testDejafusWithSettings settings [(name, p)]
 
 -- | Variant of 'testDejafu' which takes a collection of predicates to
--- test. This will share work between the predicates, rather than
--- running the concurrent computation many times for each predicate.
+-- test.
 --
 -- @since 2.0.0.0
 testDejafus :: Show b


### PR DESCRIPTION
The `testDejafus` functions in hunit-dejafu and tasty-dejafu say that they share work.  This isn't true, and actually hasn't been true since discard functions were introduced in 2017 by db95dde7dff9c2a94bc00a550264aa91c7dc8787, since that commit removed the sharing of traces.

**Related issues:** #361