### PR TITLE
Release hunit-dejafu-2.0.0.6 & tasty-dejafu-2.0.0.9

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,7 +44,7 @@ There are a few different packages under the Déjà Fu umbrella:
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.11.0.2 | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 2.4.0.4  | Systematic testing for Haskell concurrency. |
-| [hunit-dejafu][h:hunit]  | 2.0.0.5  | Deja Fu support for the HUnit test framework. |
+| [hunit-dejafu][h:hunit]  | 2.0.0.6  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 2.0.0.8  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.

--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,7 @@ There are a few different packages under the Déjà Fu umbrella:
 | [concurrency][h:conc]    | 1.11.0.2 | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 2.4.0.4  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.6  | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 2.0.0.8  | Deja Fu support for the Tasty test framework. |
+| [tasty-dejafu][h:tasty]  | 2.0.0.9  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -29,7 +29,7 @@ There are a few different packages under the Déjà Fu umbrella:
 
    ":hackage:`concurrency`",  "1.11.0.2", "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "2.4.0.4",  "Systematic testing for Haskell concurrency"
-   ":hackage:`hunit-dejafu`", "2.0.0.5",  "Déjà Fu support for the HUnit test framework"
+   ":hackage:`hunit-dejafu`", "2.0.0.6",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "2.0.0.8",  "Déjà Fu support for the tasty test framework"
 
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -30,7 +30,7 @@ There are a few different packages under the Déjà Fu umbrella:
    ":hackage:`concurrency`",  "1.11.0.2", "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "2.4.0.4",  "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.6",  "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "2.0.0.8",  "Déjà Fu support for the tasty test framework"
+   ":hackage:`tasty-dejafu`", "2.0.0.9",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/hunit-dejafu/CHANGELOG.rst
+++ b/hunit-dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+2.0.0.6 (2022-08-30)
+--------------------
+
+* Git: :tag:`hunit-dejafu-2.0.0.6`
+* Hackage: :hackage:`hunit-dejafu-2.0.0.6`
 
 Fixed
 ~~~~~

--- a/hunit-dejafu/hunit-dejafu.cabal
+++ b/hunit-dejafu/hunit-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hunit-dejafu
-version:             2.0.0.5
+version:             2.0.0.6
 synopsis:            Deja Fu support for the HUnit test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      hunit-dejafu-2.0.0.5
+  tag:      hunit-dejafu-2.0.0.6
 
 library
   exposed-modules:     Test.HUnit.DejaFu

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+2.0.0.9 (2022-08-30)
+--------------------
+
+* Git: :tag:`tasty-dejafu-2.0.0.9`
+* Hackage: :hackage:`tasty-dejafu-2.0.0.9`
 
 Fixed
 ~~~~~

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             2.0.0.8
+version:             2.0.0.9
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-2.0.0.8
+  tag:      tasty-dejafu-2.0.0.9
 
 library
   exposed-modules:     Test.Tasty.DejaFu


### PR DESCRIPTION
These releases fix some incorrect comments.