### PR TITLE
Make tasty-dejafu multi-predicate functions take the test group name

### DIFF
--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,23 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Changed
+~~~~~~~
+
+* (:issue:`361`) The following functions take a ``TestName`` parameter
+  to name the test group, rather than using "Deja Fu Tests":
+
+  * ``Test.Tasty.DejaFu.testAuto``
+  * ``Test.Tasty.DejaFu.testAutoWay``
+  * ``Test.Tasty.DejaFu.testAutoWithSettings``
+  * ``Test.Tasty.DejaFu.testDejafus``
+  * ``Test.Tasty.DejaFu.testDejafusWay``
+  * ``Test.Tasty.DejaFu.testDejafusWithSettings``
+
+
 2.0.0.9 (2022-08-30)
 --------------------
 


### PR DESCRIPTION
These functions were added way back in the day to share work between a
group of predicates.  That functionality was dropped in 2017 when
bound threads were implemented and running all tests began to require
IO (#157) - confusingly, the comment about sharing work was kept for 5
more years (until #362).

hunit-dejafu has very similar functions, and I wanted to make the APIs
of both packages identical so far as possible.  HUnit supports
nameless test groups.  Tasty does not.  To keep the API the same as
hunit-dejafu, I filled in a default group name: "Deja Fu Tests".

But an unchangeable name isn't conducive to good testsuite output, and
it's time to fix that mistake.

I considered deprecating these functions instead, but they're not
really causing any problems as such, so there's no harm in keeping
them.

**Related issues:** #157, #361, #362