### PR TITLE
Add GHC 9.2 to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
           - lts-15.0 # ghc-8.8
           - lts-17.0 # ghc-8.10
           - lts-19.0 # ghc-9.0
+          - lts-20.0 # ghc-9.2
 
     steps:
       - uses: actions/checkout@v3
@@ -95,7 +96,7 @@ jobs:
           if [[ "$RESOLVER" == "lts-9.0" ]]; then
             export PATH=$HOME/.local/bin:$PATH
           fi
-          stack --no-terminal build --ghc-options="-Werror -Wno-unused-imports"
+          stack --no-terminal build --ghc-options="-Werror -Wno-unused-imports -Wno-incomplete-uni-patterns"
       - name: Test
         env:
           RESOLVER: ${{ matrix.resolver }}

--- a/concurrency/Control/Concurrent/Classy/Async.hs
+++ b/concurrency/Control/Concurrent/Classy/Async.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 
 -- |
@@ -174,7 +175,11 @@ instance (MonadConc m, Semigroup a) => Semigroup (Concurrently m a) where
 -- | @since 1.1.2.0
 instance (MonadConc m, Monoid a) => Monoid (Concurrently m a) where
   mempty = pure mempty
+#if MIN_VERSION_base(4,11,0)
+  mappend = (<>)
+#else
   mappend = liftA2 mappend
+#endif
 
 -------------------------------------------------------------------------------
 -- Spawning

--- a/dejafu-tests/lib/Integration/Regressions.hs
+++ b/dejafu-tests/lib/Integration/Regressions.hs
@@ -6,6 +6,7 @@ import           Test.DejaFu               (exceptionsAlways, gives')
 
 import           Control.Concurrent.Classy
 import           Control.Exception         (AsyncException(..))
+import           Control.Monad             (void)
 import qualified Control.Monad.Catch       as E
 import           System.Random             (mkStdGen)
 
@@ -45,10 +46,10 @@ tests = toTestList
         (\_ -> pure ())
 
   , djfu "https://github.com/barrucadu/dejafu/issues/161" (gives' [Just (), Nothing]) $ do
-      let try a = (a >> pure ()) `E.catch` (\(_ :: E.SomeException) -> pure ())
+      let try a = void a `E.catch` (\(_ :: E.SomeException) -> pure ())
       let act s = uninterruptibleMask_ (putMVar s ())
       s <- newEmptyMVar
-      t <- mask $ \restore -> fork (try (restore (act s)) >> pure ())
+      t <- mask $ \restore -> fork (void (try (restore (act s))))
       killThread t
       tryReadMVar s
 

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -8,7 +8,7 @@ currently supported versions are:
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
-   "9.2",  "",         "4.16.0.0"
+   "9.2",  "LTS 20.0", "4.16.0.0"
    "9.0",  "LTS 19.0", "4.15.0.0"
    "8.10", "LTS 17.0", "4.14.1.0"
    "8.8",  "LTS 15.0", "4.13.0.0"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-07-01
+resolver: lts-20.0
 
 packages:
 - concurrency


### PR DESCRIPTION
Can't add 9.4 yet, because there isn't a nightly with `criterion`, which is a dependency of dejafu-tests.