### PR TITLE
Bump upper bounds of mtl & transformers, + new releases

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,7 @@ There are a few different packages under the Déjà Fu umbrella:
 |   | Version | Summary |
 | - | ------- | ------- |
 | [concurrency][h:conc]    | 1.11.0.3 | Typeclasses, functions, and data types for concurrency and STM. |
-| [dejafu][h:dejafu]       | 2.4.0.4  | Systematic testing for Haskell concurrency. |
+| [dejafu][h:dejafu]       | 2.4.0.5  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.6  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 2.1.0.0  | Deja Fu support for the Tasty test framework. |
 

--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ There are a few different packages under the Déjà Fu umbrella:
 
 |   | Version | Summary |
 | - | ------- | ------- |
-| [concurrency][h:conc]    | 1.11.0.2 | Typeclasses, functions, and data types for concurrency and STM. |
+| [concurrency][h:conc]    | 1.11.0.3 | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 2.4.0.4  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.6  | Deja Fu support for the HUnit test framework. |
 | [tasty-dejafu][h:tasty]  | 2.1.0.0  | Deja Fu support for the Tasty test framework. |

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+1.11.0.3 (2023-06-17)
+---------------------
+
+* Git: :tag:`concurrency-1.11.0.3`
+* Hackage: :hackage:`concurrency-1.11.0.3`
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/concurrency/CHANGELOG.rst
+++ b/concurrency/CHANGELOG.rst
@@ -7,6 +7,16 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`mtl` is <2.4.
+* The upper bound on :hackage:`transformers` is <0.7.
+
+
 1.11.0.2 (2021-08-15)
 ---------------------
 

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                concurrency
-version:             1.11.0.2
+version:             1.11.0.3
 synopsis:            Typeclasses, functions, and data types for concurrency and STM.
 
 description:
@@ -32,7 +32,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      concurrency-1.11.0.2
+  tag:      concurrency-1.11.0.3
 
 library
   exposed-modules:     Control.Monad.Conc.Class

--- a/concurrency/concurrency.cabal
+++ b/concurrency/concurrency.cabal
@@ -65,9 +65,9 @@ library
                      , atomic-primops    >=0.8  && <0.9
                      , exceptions        >=0.7  && <0.11
                      , monad-control     >=1.0  && <1.1
-                     , mtl               >=2.2  && <2.3
+                     , mtl               >=2.2  && <2.4
                      , stm               >=2.4  && <2.6
-                     , transformers      >=0.5  && <0.6
+                     , transformers      >=0.5  && <0.7
   -- hs-source-dirs:      
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/dejafu-tests/lib/Examples/ParMonad/Direct.hs
+++ b/dejafu-tests/lib/Examples/ParMonad/Direct.hs
@@ -90,7 +90,10 @@ import           System.IO.Unsafe                              (unsafePerformIO)
 import qualified System.Random.MWC                             as Random
 
 import           Control.DeepSeq
-import           Control.Monad                                 (replicateM)
+import           Control.Monad                                 (join,
+                                                                replicateM,
+                                                                unless)
+import           Data.Foldable                                 (forM_)
 import qualified Data.Set                                      as S
 import           Data.Word                                     (Word64)
 

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+2.4.0.5 (2023-06-17)
+--------------------
+
+* Git: :tag:`dejafu-2.4.0.5`
+* Hackage: :hackage:`dejafu-2.4.0.5`
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,15 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`transformers` is <0.7.
+
+
 2.4.0.4 (2022-08-22)
 --------------------
 

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -67,7 +67,7 @@ library
                      , leancheck         >=0.6 && <2
                      , profunctors       >=4.0 && <6
                      , random            >=1.0 && <1.3
-                     , transformers      >=0.5 && <0.6
+                     , transformers      >=0.5 && <0.7
   -- hs-source-dirs:      
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dejafu
-version:             2.4.0.4
+version:             2.4.0.5
 synopsis:            A library for unit-testing concurrent programs.
 
 description:
@@ -33,7 +33,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      dejafu-2.4.0.4
+  tag:      dejafu-2.4.0.5
 
 library
   exposed-modules:     Test.DejaFu

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,7 +27,7 @@ There are a few different packages under the Déjà Fu umbrella:
 .. csv-table::
    :header: "Package", "Version", "Summary"
 
-   ":hackage:`concurrency`",  "1.11.0.2", "Typeclasses, functions, and data types for concurrency and STM"
+   ":hackage:`concurrency`",  "1.11.0.3", "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "2.4.0.4",  "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.6",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "2.1.0.0",  "Déjà Fu support for the tasty test framework"

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -28,7 +28,7 @@ There are a few different packages under the Déjà Fu umbrella:
    :header: "Package", "Version", "Summary"
 
    ":hackage:`concurrency`",  "1.11.0.3", "Typeclasses, functions, and data types for concurrency and STM"
-   ":hackage:`dejafu`",       "2.4.0.4",  "Systematic testing for Haskell concurrency"
+   ":hackage:`dejafu`",       "2.4.0.5",  "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.6",  "Déjà Fu support for the HUnit test framework"
    ":hackage:`tasty-dejafu`", "2.1.0.0",  "Déjà Fu support for the tasty test framework"
 


### PR DESCRIPTION
Bump the upper bound of mtl to `<2.4` and the upper bound of transformers to `<0.7`, and make new patch releases of concurrency and dejafu.
