### PR TITLE
Add GHC 9.4 to build matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
           - lts-17.0 # ghc-8.10
           - lts-19.0 # ghc-9.0
           - lts-20.0 # ghc-9.2
+          - nightly-2023-01-01 # ghc-9.4
 
     steps:
       - uses: actions/checkout@v3

--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,15 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* Fix GHC compatibility warning.
+
+
 2.4.0.5 (2023-06-17)
 --------------------
 

--- a/dejafu/Test/DejaFu/Conc/Internal/Common.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Common.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- |
 -- Module      : Test.DejaFu.Conc.Internal.Common

--- a/dejafu/Test/DejaFu/Conc/Internal/Program.hs
+++ b/dejafu/Test/DejaFu/Conc/Internal/Program.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- GHC doesn't need this to compile the module, but stylish-haskell
 -- does to format it.

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -2,12 +2,13 @@ Supported GHC Versions
 ======================
 
 Déjà Fu supports the latest four GHC releases, at least.  For testing
-purposes, we use Stackage LTSes as a proxy for GHC versions.  The
+purposes, we use Stackage snapshots as a proxy for GHC versions.  The
 currently supported versions are:
 
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
+   "9.4",  "Nightly 2023-01-01", "4.17.0.0"
    "9.2",  "LTS 20.0", "4.16.0.0"
    "9.0",  "LTS 19.0", "4.15.0.0"
    "8.10", "LTS 17.0", "4.14.1.0"
@@ -34,12 +35,12 @@ cause a **patch level version bump**.
 3. Remove any unsupported versions from the table.
 4. Make a patch release.
 
-A new GHC release won't get a Stackage LTS for little while.  When it
+A new GHC release won't get a Stackage snapshot for little while.  When it
 does:
 
-1. Add the LTS to the GitHub Actions configuration.
+1. Add the snapshot to the GitHub Actions configuration.
 2. Update the resolver in the stack.yaml.
-3. Put the LTS in the table.
+3. Put the snapshot in the table.
 
 
 Dropping old GHC releases


### PR DESCRIPTION
Looks like this isn't getting an LTS, so just stick a nightly here, and relax the restriction on only using LTSes anyway.