### PR TITLE
Add GHC 9.6 to build matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           - lts-17.0 # ghc-8.10
           - lts-19.0 # ghc-9.0
           - lts-20.0 # ghc-9.2
-          - nightly-2023-01-01 # ghc-9.4
+          - lts-21.0 # ghc-9.4
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
           - lts-19.0 # ghc-9.0
           - lts-20.0 # ghc-9.2
           - lts-21.0 # ghc-9.4
+          - nightly-2023-07-01 # ghc-9.6
 
     steps:
       - uses: actions/checkout@v3

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -8,6 +8,7 @@ currently supported versions are:
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
+   "9.6",  "Nightly 2021-07-01", "4.18.0.0"
    "9.4",  "LTS 21.0", "4.17.0.0"
    "9.2",  "LTS 20.0", "4.16.0.0"
    "9.0",  "LTS 19.0", "4.15.0.0"

--- a/doc/ghc.rst
+++ b/doc/ghc.rst
@@ -8,7 +8,7 @@ currently supported versions are:
 .. csv-table::
    :header: "GHC", "Stackage", "base"
 
-   "9.4",  "Nightly 2023-01-01", "4.17.0.0"
+   "9.4",  "LTS 21.0", "4.17.0.0"
    "9.2",  "LTS 20.0", "4.16.0.0"
    "9.0",  "LTS 19.0", "4.15.0.0"
    "8.10", "LTS 17.0", "4.14.1.0"


### PR DESCRIPTION
Also use LTS 21.0 for the GHC 9.4 build.