### PR TITLE
Bump tasty upper bound to <1.6 & release tasty-dejafu

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,7 @@ There are a few different packages under the Déjà Fu umbrella:
 | [concurrency][h:conc]    | 1.11.0.3 | Typeclasses, functions, and data types for concurrency and STM. |
 | [dejafu][h:dejafu]       | 2.4.0.5  | Systematic testing for Haskell concurrency. |
 | [hunit-dejafu][h:hunit]  | 2.0.0.6  | Deja Fu support for the HUnit test framework. |
-| [tasty-dejafu][h:tasty]  | 2.1.0.0  | Deja Fu support for the Tasty test framework. |
+| [tasty-dejafu][h:tasty]  | 2.1.0.1  | Deja Fu support for the Tasty test framework. |
 
 Each package has its own README and CHANGELOG in its subdirectory.
 

--- a/dejafu-tests/exe/MainBench.hs
+++ b/dejafu-tests/exe/MainBench.hs
@@ -15,7 +15,12 @@ main = C.defaultMain (T.foldTestTree mkBench mempty tests)
 
 -- | Turn a test tree into a list of benchmarks.
 mkBench :: T.TreeFold [C.Benchmark]
-#if MIN_VERSION_tasty(1,4,0)
+#if MIN_VERSION_tasty(1,5,0)
+mkBench = T.trivialFold
+  { T.foldSingle = \opts lbl t -> [C.bench lbl (benchTest opts t)]
+  , T.foldGroup = \_ lbl bs -> map (C.bgroup lbl) bs
+  }
+#elif MIN_VERSION_tasty(1,4,0)
 mkBench = T.trivialFold
   { T.foldSingle = \opts lbl t -> [C.bench lbl (benchTest opts t)]
   , T.foldGroup = \_ lbl bs -> [C.bgroup lbl bs]

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -30,7 +30,7 @@ There are a few different packages under the Déjà Fu umbrella:
    ":hackage:`concurrency`",  "1.11.0.3", "Typeclasses, functions, and data types for concurrency and STM"
    ":hackage:`dejafu`",       "2.4.0.5",  "Systematic testing for Haskell concurrency"
    ":hackage:`hunit-dejafu`", "2.0.0.6",  "Déjà Fu support for the HUnit test framework"
-   ":hackage:`tasty-dejafu`", "2.1.0.0",  "Déjà Fu support for the tasty test framework"
+   ":hackage:`tasty-dejafu`", "2.1.0.1",  "Déjà Fu support for the tasty test framework"
 
 
 Installation

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,8 +7,11 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
-unreleased
-----------
+2.1.0.1 (2023-09-11)
+--------------------
+
+* Git: :tag:`tasty-dejafu-2.1.0.1`
+* Hackage: :hackage:`tasty-dejafu-2.1.0.1`
 
 Miscellaneous
 ~~~~~~~~~~~~~

--- a/tasty-dejafu/CHANGELOG.rst
+++ b/tasty-dejafu/CHANGELOG.rst
@@ -7,6 +7,15 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`tasty` is <1.6.
+
+
 2.1.0.0 (2022-08-31)
 --------------------
 

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -40,6 +40,6 @@ library
                      , dejafu >=2.0  && <2.5
                      , random >=1.0  && <1.3
                      , tagged >=0.8  && <0.9
-                     , tasty  >=0.10 && <1.5
+                     , tasty  >=0.10 && <1.6
   -- hs-source-dirs:      
   default-language:    Haskell2010

--- a/tasty-dejafu/tasty-dejafu.cabal
+++ b/tasty-dejafu/tasty-dejafu.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-dejafu
-version:             2.1.0.0
+version:             2.1.0.1
 synopsis:            Deja Fu support for the Tasty test framework.
 
 description:
@@ -30,7 +30,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/barrucadu/dejafu.git
-  tag:      tasty-dejafu-2.1.0.0
+  tag:      tasty-dejafu-2.1.0.1
 
 library
   exposed-modules:     Test.Tasty.DejaFu


### PR DESCRIPTION
Bump the upper bound of tasty to `<1.6` and make a new patch release of tasty-dejafu.