### PR TITLE
Bump containers upper bound to <0.9

### DIFF
--- a/dejafu/CHANGELOG.rst
+++ b/dejafu/CHANGELOG.rst
@@ -7,6 +7,15 @@ standard Haskell versioning scheme.
 .. _PVP: https://pvp.haskell.org/
 
 
+unreleased
+----------
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+* The upper bound on :hackage:`containers` is <0.9.
+
+
 2.4.0.7 (2025-01-06)
 --------------------
 

--- a/dejafu/dejafu.cabal
+++ b/dejafu/dejafu.cabal
@@ -60,7 +60,7 @@ library
   -- other-extensions:
   build-depends:       base              >=4.9 && <5
                      , concurrency       >=1.11 && <1.12
-                     , containers        >=0.5 && <0.8
+                     , containers        >=0.5 && <0.9
                      , contravariant     >=1.2 && <1.6
                      , deepseq           >=1.1 && <2
                      , exceptions        >=0.7 && <0.11


### PR DESCRIPTION
Breaking changes don't affect dejafu.